### PR TITLE
Add support for multiple VNC encodings

### DIFF
--- a/RemoteViewing.Tests/Vnc/Server/RawEncoderTests.cs
+++ b/RemoteViewing.Tests/Vnc/Server/RawEncoderTests.cs
@@ -1,0 +1,70 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using RemoteViewing.Vnc;
+using RemoteViewing.Vnc.Server;
+using System.IO;
+using Xunit;
+
+namespace RemoteViewing.Tests.Vnc.Server
+{
+    /// <summary>
+    /// Tests the <see cref="RawEncoder"/> class.
+    /// </summary>
+    public class RawEncoderTests
+    {
+        /// <summary>
+        /// Tests the <see cref="RawEncoder.Encoding"/> property.
+        /// </summary>
+        [Fact]
+        public void EncodingTest()
+        {
+            var encoder = new RawEncoder();
+            Assert.Equal(VncEncoding.Raw, encoder.Encoding);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RawEncoder.Send"/> method.
+        /// </summary>
+        [Fact]
+        public void SendTest()
+        {
+            RawEncoder encoder = new RawEncoder();
+            byte[] content = { 0x01, 0x02, 0x03, 0x04 };
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                // The encoder should write the content 'as is' to the stream.
+                encoder.Send(stream, new VncPixelFormat(), content);
+
+                Assert.Equal(content, stream.ToArray());
+            }
+        }
+    }
+}

--- a/RemoteViewing/Vnc/Server/RawEncoder.cs
+++ b/RemoteViewing/Vnc/Server/RawEncoder.cs
@@ -1,0 +1,54 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System.IO;
+
+namespace RemoteViewing.Vnc.Server
+{
+    /// <summary>
+    /// Represents the raw VNC encoding protocol.
+    /// </summary>
+    /// <remarks>
+    /// The simplest encoding type is raw pixel data. In this case the data consists of width * height pixel values
+    /// (where width and height are the width and height of the rectangle). The values simply represent each pixel
+    /// in left-to-right scanline order.
+    /// </remarks>
+    /// <seealso href="https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#raw-encoding"/>.
+    internal class RawEncoder : VncEncoder
+    {
+        /// <inheritdoc/>
+        public override VncEncoding Encoding => VncEncoding.Raw;
+
+        /// <inheritdoc/>
+        public override void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents)
+        {
+            stream.Write(contents, 0, contents.Length);
+        }
+    }
+}

--- a/RemoteViewing/Vnc/Server/VncEncoder.cs
+++ b/RemoteViewing/Vnc/Server/VncEncoder.cs
@@ -1,0 +1,58 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System.IO;
+
+namespace RemoteViewing.Vnc.Server
+{
+    /// <summary>
+    /// A common base class for VNC encoders.
+    /// </summary>
+    internal abstract class VncEncoder
+    {
+        /// <summary>
+        /// Gets the <see cref="VncEncoder"/> protocol implemented by this <see cref="VncEncoder"/>.
+        /// </summary>
+        public abstract VncEncoding Encoding { get; }
+
+        /// <summary>
+        /// Sends the contents of a rectangle to the client.
+        /// </summary>
+        /// <param name="stream">
+        /// A <see cref="Stream"/> which represents the connection to the VNC client.
+        /// </param>
+        /// <param name="pixelFormat">
+        /// The <see cref="VncPixelFormat"/> being used.
+        /// </param>
+        /// <param name="contents">
+        /// The contents of the rectangle, in raw pixel format.
+        /// </param>
+        public abstract void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents);
+    }
+}

--- a/RemoteViewing/Vnc/Server/VncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/VncServerSession.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using RemoteViewing.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -63,6 +64,7 @@ namespace RemoteViewing.Vnc.Server
         MemoryStream _zlibMemoryStream;
         DeflateStream _zlibDeflater;
 #endif
+        private VncEncoder encoder = new RawEncoder();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VncServerSession"/> class.
@@ -520,9 +522,12 @@ namespace RemoteViewing.Vnc.Server
 
                 foreach (var rectangle in this.fbuRectangles)
                 {
+                    Debug.Assert(rectangle.Encoding == VncEncoding.Raw, "Rectangles should be in raw format");
+
                     this.c.SendRectangle(rectangle.Region);
-                    this.c.SendUInt32BE((uint)rectangle.Encoding);
-                    this.c.Send(rectangle.Contents);
+                    this.c.SendUInt32BE((uint)this.encoder.Encoding);
+
+                    this.encoder.Send(this.c.Stream, this.clientPixelFormat, rectangle.Contents);
                 }
 
                 this.fbuRectangles.Clear();


### PR DESCRIPTION
This PR adds the `VncEncoder` class, which is responsible for receiving a raw (uncompressed) rectangle, encoding it and sending it to the client.

Currently only `VncRawEncoder` is implemented, which makes it a no-op. Tight encoding will come in a follow-up PR.