### PR TITLE
Try with the previous AppVeyor image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 
 before_build:
   - cmd: choco install codecov


### PR DESCRIPTION
Not sure what broke (there's an update to a new version of the .NET Core SDK, so it's most likely that). We're moving to Azure Pipelines anyway, so a quick workaround to keep builds going should be fine.