### PR TITLE
Add Tight encoder

### DIFF
--- a/RemoteViewing.Tests/Vnc/Server/TightEncoderTests.cs
+++ b/RemoteViewing.Tests/Vnc/Server/TightEncoderTests.cs
@@ -1,0 +1,160 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using RemoteViewing.Vnc;
+using RemoteViewing.Vnc.Server;
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace RemoteViewing.Tests.Vnc.Server
+{
+    /// <summary>
+    /// Tests the <see cref="TightEncoder"/> class.
+    /// </summary>
+    public class TightEncoderTests
+    {
+        /// <summary>
+        /// Tests the <see cref="TightEncoder.WriteEncodedValue(byte[], int, int)"/> method.
+        /// </summary>
+        [Fact]
+        public void WriteEncodedValueTest()
+        {
+            byte[] buffer = new byte[4];
+
+            for (int i = 0; i < 64; i++)
+            {
+                Assert.Equal(1, TightEncoder.WriteEncodedValue(buffer, 0, i));
+                Assert.Equal((byte)i, buffer[0]);
+            }
+
+            Assert.Equal(2, TightEncoder.WriteEncodedValue(buffer, 0, 10_000));
+            Assert.Equal(0x90, buffer[0]);
+            Assert.Equal(0x4E, buffer[1]);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="TightEncoder.Send(Stream, VncPixelFormat, byte[])"/> method in a scenario where the
+        /// standard (non-tight) pixel format is used.
+        /// </summary>
+        [Fact]
+        public void SendTestStandardPixelFormat()
+        {
+            TightEncoder encoder = new TightEncoder();
+
+            byte[] raw = null;
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                var contents = Encoding.ASCII.GetBytes("hello, world\n");
+                encoder.Send(output, new VncPixelFormat(32, 24, 8, 0, 8, 0, 8, 0, false, true), contents);
+                raw = output.ToArray();
+            }
+
+            // First byte:
+            // - Basic compression
+            // - Use stream 0
+            // - Reset stream 0
+            Assert.Equal(0b0000_0001, raw[0]);
+
+            byte[] expectedZlibData = new byte[] { 0x78, 0x9c, 0xcb, 0x48, 0xcd, 0xc9, 0xc9, 0xd7, 0x51, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0xe1, 0x02, 0x00, 0x21, 0xe7, 0x04, 0x93 };
+            byte[] actualZlibData = new byte[raw.Length - 2];
+            Array.Copy(raw, 2, actualZlibData, 0, raw.Length - 2);
+
+            Assert.Equal((byte)expectedZlibData.Length, raw[1]);
+            Assert.Equal(expectedZlibData, actualZlibData);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="TightEncoder.Send(Stream, VncPixelFormat, byte[])"/> method in a scenario where the
+        /// tight pixel format is used.
+        /// </summary>
+        [Fact]
+        public void SendTightPixelFormat()
+        {
+            TightEncoder encoder = new TightEncoder();
+
+            byte[] raw = null;
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                var contents = Encoding.ASCII.GetBytes("hello, world    ");
+                encoder.Send(output, new VncPixelFormat(), contents);
+                raw = output.ToArray();
+            }
+
+            // First byte:
+            // - Basic compression
+            // - Use stream 0
+            // - Reset stream 0
+            Assert.Equal(0b0000_0001, raw[0]);
+
+            byte[] expectedZlibData = new byte[] { 0x78, 0x9c, 0xcb, 0x48, 0xcd, 0xc9, 0xd7, 0x51, 0xc8, 0x2f, 0xca, 0x51, 0x50, 0x50, 0x00, 0x00, 0x1a, 0xe6, 0x03, 0xa2 };
+
+            byte[] actualZlibData = new byte[raw.Length - 2];
+            Array.Copy(raw, 2, actualZlibData, 0, raw.Length - 2);
+
+            Assert.Equal((byte)expectedZlibData.Length, raw[1]);
+            Assert.Equal(expectedZlibData, actualZlibData);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="TightEncoder.Send(Stream, VncPixelFormat, byte[])"/> method in a scenario where the
+        /// uncompressed data is less than 12 bytes long, causing the encoder not to use any compression.
+        /// </summary>
+        [Fact]
+        public void SendSmallRectangleFormat()
+        {
+            TightEncoder encoder = new TightEncoder();
+
+            byte[] raw = null;
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                var contents = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+                encoder.Send(output, new VncPixelFormat(), contents);
+                raw = output.ToArray();
+            }
+
+            // First byte:
+            // - Basic compression
+            // - Use stream 0
+            // - Reset stream 0
+            Assert.Equal(0b0000_0000, raw[0]);
+
+            byte[] expectedZlibData = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+
+            byte[] actualZlibData = new byte[raw.Length - 2];
+            Array.Copy(raw, 2, actualZlibData, 0, raw.Length - 2);
+
+            Assert.Equal((byte)expectedZlibData.Length, raw[1]);
+            Assert.Equal(expectedZlibData, actualZlibData);
+        }
+    }
+}

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -24,9 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All"/>
+    <PackageReference Include="sharpcompress" Version="0.24.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>

--- a/RemoteViewing/Vnc/Server/TightCompressionControl.cs
+++ b/RemoteViewing/Vnc/Server/TightCompressionControl.cs
@@ -1,0 +1,100 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System;
+
+namespace RemoteViewing.Vnc.Server
+{
+    /// <summary>
+    /// Control flags used by the Tight compression protocol.
+    /// </summary>
+    [Flags]
+    internal enum TightCompressionControl : byte
+    {
+        /// <summary>
+        /// Informs the client zlib compression stream at index 0 should be reset before decoding the rectangle.
+        /// </summary>
+        ResetStream0 = 0b_0001,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 1 should be reset before decoding the rectangle.
+        /// </summary>
+        ResetStream1 = 0b_0010,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 2 should be reset before decoding the rectangle.
+        /// </summary>
+        ResetStream2 = 0b_0100,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 3 should be reset before decoding the rectangle.
+        /// </summary>
+        ResetStream3 = 0b_10100,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 0 should be used to decode the rectangle.
+        /// </summary>
+        UseStream0 = 0b_0000_0000,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 1 should be used to decode the rectangle.
+        /// </summary>
+        UseStream1 = 0b_0001_0000,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 2 should be used to decode the rectangle.
+        /// </summary>
+        UseStream2 = 0b_0010_0000,
+
+        /// <summary>
+        /// Informs the client zlib compression stream at index 3 should be used to decode the rectangle.
+        /// </summary>
+        UseStream3 = 0b_0011_0000,
+
+        /// <summary>
+        /// Informs the client the next byte specifies the <c>filter-id</c> value which tells the decoder
+        /// what filter type was used by the encoder to pre-process pixel data before the compression.
+        /// </summary>
+        ReadFilterId = 0b_0100_0000,
+
+        /// <summary>
+        /// Informs the client basic compression has been used.
+        /// </summary>
+        BasicCompression = 0b_0000_0000,
+
+        /// <summary>
+        /// Informs the client fill compression has been used.
+        /// </summary>
+        FillCompression = 0b_1000_0000,
+
+        /// <summary>
+        /// Informs the client JPEG compression has been used.
+        /// </summary>
+        JpegCompression = 0b_1001_0000,
+    }
+}

--- a/RemoteViewing/Vnc/Server/TightEncoder.cs
+++ b/RemoteViewing/Vnc/Server/TightEncoder.cs
@@ -1,0 +1,138 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.Deflate;
+using System.Diagnostics;
+using System.IO;
+
+namespace RemoteViewing.Vnc.Server
+{
+    /// <summary>
+    /// Tight encoding provides efficient compression for pixel data, using zlib compression (over 4 multiple zlib streams),
+    /// JPEG compression or fill compression, and optionally applying filters to the raw pixel data.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="TightEncoder"/> currently only implements zlib compression over a single zlib stream,
+    /// which is reset after every rectangle.
+    /// </remarks>
+    /// <seealso href="https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#tight-encoding"/>
+    internal class TightEncoder : VncEncoder
+    {
+        /// <inheritdoc/>
+        public override VncEncoding Encoding => VncEncoding.Tight;
+
+        /// <summary>Encode a value into a byte array</summary>
+        /// <param name="buffer">The byte array to encode the 7-bit integer into</param>
+        /// <param name="startIndex">The index of the first byte for the 7-bit integer</param>
+        /// <param name="value">The value to encode into <paramref name="buffer"/></param>
+        /// <returns>Index of the first byte after the encoded value in <paramref name="buffer"/></returns>
+        public static int WriteEncodedValue(byte[] buffer, int startIndex, int value)
+        {
+            // Write out an int 7 bits at a time.  The high bit of the byte,
+            // when on, tells reader to continue reading more bytes.
+            uint v = (uint)value;
+            for (; v >= 0x80; v >>= 7, startIndex++)
+            {
+                buffer[startIndex] = (byte)(v | 0x80);
+            }
+
+            buffer[startIndex++] = (byte)v;
+
+            return startIndex;
+        }
+
+        /// <inheritdoc/>
+        public override void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents)
+        {
+            if (contents.Length < 12)
+            {
+                var compressionControl = TightCompressionControl.BasicCompression;
+                stream.WriteByte((byte)compressionControl);
+
+                // If the data size after applying the filter but before the compression is less then 12, then the data is sent as is, uncompressed.
+                byte[] encodedBuffer = new byte[4];
+                var length = WriteEncodedValue(encodedBuffer, 0, (int)contents.Length);
+                stream.Write(encodedBuffer, 0, length);
+
+                stream.Write(contents, 0, contents.Length);
+            }
+            else
+            {
+                var compressionControl = TightCompressionControl.BasicCompression
+                    | TightCompressionControl.ResetStream0
+                    | TightCompressionControl.UseStream0;
+
+                stream.WriteByte((byte)compressionControl);
+
+                using (var buffer = new MemoryStream())
+                using (var deflater = new ZlibStream(buffer, CompressionMode.Compress))
+                {
+                    // The Tight encoding makes use of a new type TPIXEL (Tight pixel). This is the same as a PIXEL for the agreed
+                    // pixel format, except where true-colour-flag is non-zero, bits-per-pixel is 32, depth is 24 and all of the bits
+                    // making up the red, green and blue intensities are exactly 8 bits wide.
+                    // In this case a TPIXEL is only 3 bytes long, where the first byte is the red component, the second byte is the
+                    // green component, and the third byte is the blue component of the pixel color value.
+                    if (pixelFormat.BitsPerPixel == 32
+                        && pixelFormat.BitDepth == 24
+                        && pixelFormat.BlueBits == 8
+                        && pixelFormat.RedBits == 8
+                        && pixelFormat.GreenBits == 8
+                        && !pixelFormat.IsPalettized)
+                    {
+                        Debug.Assert(contents.Length % 4 == 0, "The size of the raw pixel data must be a multiple of 4 when using a 32bpp pixel format.");
+
+                        for (int i = 0; i < contents.Length; i += 4)
+                        {
+                            if (i == contents.Length - 4)
+                            {
+                                deflater.FlushMode = FlushType.Finish;
+                            }
+
+                            deflater.Write(contents, i, 3);
+                        }
+                    }
+                    else
+                    {
+                        deflater.FlushMode = FlushType.Finish;
+                        deflater.Write(contents, 0, contents.Length);
+                    }
+
+                    deflater.Flush();
+
+                    byte[] encodedBuffer = new byte[4];
+                    var length = WriteEncodedValue(encodedBuffer, 0, (int)buffer.Length);
+                    stream.Write(encodedBuffer, 0, length);
+
+                    buffer.Position = 0;
+                    buffer.CopyTo(stream);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a very basic implementation of a Tight encoder, which _only_ supports zlib compression using a _single_ zlib stream which is _always_ reset (i.e. for every rectangle).

Tested to be compatible with noVNC.