### PR TITLE
VncPixelFormat improvements

### DIFF
--- a/RemoteViewing.Tests/Vnc/VncPixelFormatTests.cs
+++ b/RemoteViewing.Tests/Vnc/VncPixelFormatTests.cs
@@ -1,0 +1,127 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using RemoteViewing.Vnc;
+using System;
+using Xunit;
+
+namespace RemoteViewing.Tests.Vnc
+{
+    /// <summary>
+    /// Tests the <see cref="VncPixelFormat"/> class.
+    /// </summary>
+    public class VncPixelFormatTests
+    {
+        /// <summary>
+        /// Tests the <see cref="VncPixelFormat"/> constructors.
+        /// </summary>
+        [Fact]
+        public void ConstructorTest()
+        {
+            // Default pixel format should be RGB32.
+            var pixelFormat = new VncPixelFormat();
+            Assert.Equal(24, pixelFormat.BitDepth);
+            Assert.Equal(32, pixelFormat.BitsPerPixel);
+            Assert.Equal(4, pixelFormat.BytesPerPixel);
+
+            Assert.True(pixelFormat.IsLittleEndian);
+            Assert.False(pixelFormat.IsPalettized);
+
+            Assert.Equal(8, pixelFormat.BlueBits);
+            Assert.Equal(255, pixelFormat.BlueMax);
+            Assert.Equal(0, pixelFormat.BlueShift);
+
+            Assert.Equal(8, pixelFormat.GreenBits);
+            Assert.Equal(255, pixelFormat.GreenMax);
+            Assert.Equal(8, pixelFormat.GreenShift);
+
+            Assert.Equal(8, pixelFormat.RedBits);
+            Assert.Equal(255, pixelFormat.RedMax);
+            Assert.Equal(16, pixelFormat.RedShift);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="VncPixelFormat"/> constructor's argument validation.
+        /// </summary>
+        [Fact]
+        public void ConstuctorInvalidValuesTest()
+        {
+            // Only 8, 16 or 32 bits per pixel
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(4, 1, 1, 0, 1, 0, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(24, 1, 1, 0, 1, 0, 1, 0));
+
+            // Only bit depth of 8 or 24
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 2, 1, 0, 1, 0, 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(16, 16, 1, 0, 1, 0, 1, 0));
+
+            // Red: negative bits or shift, or bits or shift > bit depth
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, -1, 0, 8, 0, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, -1, 8, 0, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 25, 0, 8, 0, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 25, 8, 0, 8, 0));
+
+            // Blue: negative bits or shift, or bits or shift > bit depth
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, -1, 0, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, -1, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 25, 0, 8, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, 25, 8, 0));
+
+            // Green: negative bits or shift, or bits or shift > bit depth
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, 0, -1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, 0, 8, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, 0, 25, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new VncPixelFormat(8, 24, 8, 0, 8, 0, 8, 25));
+        }
+
+        /// <summary>
+        /// Tests the <see cref="VncPixelFormat.Encode(byte[], int)"/> method.
+        /// </summary>
+        [Fact]
+        public void EncodeTest()
+        {
+            var pixelFormat = new VncPixelFormat();
+            var buffer = new byte[VncPixelFormat.Size];
+            pixelFormat.Encode(buffer, 0);
+
+            var expected = new byte[] { 32, 24, 0, 1, 0, 255, 0, 255, 0, 255, 16, 8, 0, 0, 0, 0 };
+            Assert.Equal(expected, buffer);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="VncPixelFormat.Decode(byte[], int)"/> method.
+        /// </summary>
+        [Fact]
+        public void DecodeTest()
+        {
+            var buffer = new byte[] { 32, 24, 0, 1, 0, 255, 0, 255, 0, 255, 16, 8, 0, 0, 0, 0 };
+            var pixelFormat = VncPixelFormat.Decode(buffer, 0);
+            Assert.Equal(VncPixelFormat.RGB32, pixelFormat);
+        }
+    }
+}

--- a/RemoteViewing/Vnc/VncPixelFormat.cs
+++ b/RemoteViewing/Vnc/VncPixelFormat.cs
@@ -35,18 +35,6 @@ namespace RemoteViewing.Vnc
     /// </summary>
     public sealed class VncPixelFormat
     {
-        private int bitsPerPixel;
-        private int bytesPerPixel;
-        private int bitDepth;
-        private int redBits;
-        private int redShift;
-        private int greenBits;
-        private int greenShift;
-        private int blueBits;
-        private int blueShift;
-        private bool isLittleEndian;
-        private bool isPalettized;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="VncPixelFormat"/> class,
         /// with 8 bits each of red, green, and blue channels.
@@ -81,23 +69,42 @@ namespace RemoteViewing.Vnc
             bool isLittleEndian = true,
             bool isPalettized = false)
         {
-            Throw.If.False(bitsPerPixel == 8 || bitsPerPixel == 16 || bitsPerPixel == 32, "bitsPerPixel");
-            Throw.If.False(bitDepth == 24, "bitDepth");
-            Throw.If.False(redBits >= 0 && redShift >= 0 && redBits <= bitDepth && redShift <= bitDepth, "redBits");
-            Throw.If.False(greenBits >= 0 && greenShift >= 0 && greenBits <= bitDepth && greenShift <= bitDepth, "greenBits");
-            Throw.If.False(blueBits >= 0 && blueShift >= 0 && blueBits <= bitDepth && blueShift <= bitDepth, "blueBits");
+            if (bitsPerPixel != 8 && bitsPerPixel != 16 && bitsPerPixel != 32)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bitsPerPixel));
+            }
 
-            this.bitsPerPixel = bitsPerPixel;
-            this.bytesPerPixel = bitsPerPixel / 8;
-            this.bitDepth = bitDepth;
-            this.redBits = redBits;
-            this.redShift = redShift;
-            this.greenBits = greenBits;
-            this.greenShift = greenShift;
-            this.blueBits = blueBits;
-            this.blueShift = blueShift;
-            this.isLittleEndian = isLittleEndian;
-            this.isPalettized = isPalettized;
+            if (bitDepth != 8 && bitDepth != 24)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bitDepth));
+            }
+
+            if (!(redBits >= 0 && redShift >= 0 && redBits <= bitDepth && redShift <= bitDepth))
+            {
+                throw new ArgumentOutOfRangeException(nameof(redBits));
+            }
+
+            if (!(greenBits >= 0 && greenShift >= 0 && greenBits <= bitDepth && greenShift <= bitDepth))
+            {
+                throw new ArgumentOutOfRangeException(nameof(greenBits));
+            }
+
+            if (!(blueBits >= 0 && blueShift >= 0 && blueBits <= bitDepth && blueShift <= bitDepth))
+            {
+                throw new ArgumentOutOfRangeException(nameof(blueBits));
+            }
+
+            this.BitsPerPixel = bitsPerPixel;
+            this.BytesPerPixel = bitsPerPixel / 8;
+            this.BitDepth = bitDepth;
+            this.RedBits = redBits;
+            this.RedShift = redShift;
+            this.GreenBits = greenBits;
+            this.GreenShift = greenShift;
+            this.BlueBits = blueBits;
+            this.BlueShift = blueShift;
+            this.IsLittleEndian = isLittleEndian;
+            this.IsPalettized = isPalettized;
         }
 
         /// <summary>
@@ -108,50 +115,32 @@ namespace RemoteViewing.Vnc
         /// <summary>
         /// Gets the number of bits used to store a pixel.
         /// </summary>
-        public int BitsPerPixel
-        {
-            get { return this.bitsPerPixel; }
-        }
+        public int BitsPerPixel { get; private set; }
 
         /// <summary>
         /// Gets the number of bytes used to store a pixel.
         /// </summary>
-        public int BytesPerPixel
-        {
-            get { return this.bytesPerPixel; }
-        }
+        public int BytesPerPixel { get; private set; }
 
         /// <summary>
         /// Gets the bit depth of the pixel.
         /// </summary>
-        public int BitDepth
-        {
-            get { return this.bitDepth; }
-        }
+        public int BitDepth { get; private set; }
 
         /// <summary>
         /// Gets the number of bits used to represent red.
         /// </summary>
-        public int RedBits
-        {
-            get { return this.redBits; }
-        }
+        public int RedBits { get; private set; }
 
         /// <summary>
         /// Gets the number of bits left the red value is shifted.
         /// </summary>
-        public int RedShift
-        {
-            get { return this.redShift; }
-        }
+        public int RedShift { get; private set; }
 
         /// <summary>
         /// Gets the number of bits used to represent green.
         /// </summary>
-        public int GreenBits
-        {
-            get { return this.greenBits; }
-        }
+        public int GreenBits { get; private set; }
 
         /// <summary>
         /// Gets the maximum value of the red color.
@@ -192,26 +181,17 @@ namespace RemoteViewing.Vnc
         /// <summary>
         /// Gets the number of bits left the green value is shifted.
         /// </summary>
-        public int GreenShift
-        {
-            get { return this.greenShift; }
-        }
+        public int GreenShift { get; private set; }
 
         /// <summary>
         /// Gets the number of bits used to represent blue.
         /// </summary>
-        public int BlueBits
-        {
-            get { return this.blueBits; }
-        }
+        public int BlueBits { get; private set; }
 
         /// <summary>
         /// Gets the number of bits left the blue value is shifted.
         /// </summary>
-        public int BlueShift
-        {
-            get { return this.blueShift; }
-        }
+        public int BlueShift { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether the pixel is little-endian.
@@ -219,10 +199,7 @@ namespace RemoteViewing.Vnc
         /// <value>
         /// <c>true</c> if the pixel is little-endian, or <c>false</c> if it is big-endian.
         /// </value>
-        public bool IsLittleEndian
-        {
-            get { return this.isLittleEndian; }
-        }
+        public bool IsLittleEndian { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether the framebuffer stores palette indices.
@@ -230,10 +207,7 @@ namespace RemoteViewing.Vnc
         /// <value>
         /// <c>true</c> if the framebuffer stores palette indices, or <c>false</c> if it stores colors.
         /// </value>
-        public bool IsPalettized
-        {
-            get { return this.isPalettized; }
-        }
+        public bool IsPalettized { get; private set; }
 
         /// <summary>
         /// Gets the size of a <see cref="VncPixelFormat"/> when serialized to a <see cref="byte"/> array.
@@ -273,7 +247,15 @@ namespace RemoteViewing.Vnc
             int targetX = 0,
             int targetY = 0)
         {
-            Throw.If.Null(source, "source").Null(target, "target");
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
 
             if (sourceRectangle.IsEmpty)
             {
@@ -338,8 +320,25 @@ namespace RemoteViewing.Vnc
             int targetX = 0,
             int targetY = 0)
         {
-            Throw.If.True(source == IntPtr.Zero, "source").True(target == IntPtr.Zero, "target");
-            Throw.If.Null(sourceFormat, "sourceFormat").Null(targetFormat, "targetFormat");
+            if (source == IntPtr.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(source));
+            }
+
+            if (target == IntPtr.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(target));
+            }
+
+            if (sourceFormat == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sourceFormat));
+            }
+
+            if (targetFormat == null)
+            {
+                throw new ArgumentNullException(nameof(targetFormat));
+            }
 
             if (sourceRectangle.IsEmpty)
             {
@@ -443,7 +442,7 @@ namespace RemoteViewing.Vnc
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return this.bitsPerPixel ^ this.redBits;
+            return this.BitsPerPixel ^ this.RedBits;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
- Use auto properties
- Use standard argument validation methods
- Accept a bit depth of 8, as this is with RealVNC will propose first
- Add unit tests

The most important effect of this PR is a RealVNC client can now connect to the demo application. This will help us to validate the various encoders with three clients:
- noVNC
- RealVNC
- TightVNC