### PR TITLE
Simplify console application

### DIFF
--- a/RemoteViewing.ServerExample/Program.cs
+++ b/RemoteViewing.ServerExample/Program.cs
@@ -30,9 +30,9 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Windows.Forms;
+using RemoteViewing.NoVncExample;
 using RemoteViewing.Vnc;
 using RemoteViewing.Vnc.Server;
-using RemoteViewing.Windows.Forms.Server;
 
 namespace RemoteViewing.ServerExample
 {
@@ -68,7 +68,7 @@ namespace RemoteViewing.ServerExample
             Console.WriteLine("Try to connect! The password is: {0}", password);
 
             // Wait for a connection.
-            var listener = new TcpListener(IPAddress.Any, 5900);
+            var listener = new TcpListener(IPAddress.Loopback, 5900);
             listener.Start();
             var client = listener.AcceptTcpClient();
 
@@ -76,17 +76,13 @@ namespace RemoteViewing.ServerExample
             var options = new VncServerSessionOptions();
             options.AuthenticationMethod = AuthenticationMethod.Password;
 
-            // Virtual mouse
-            var mouse = new VncMouse();
-
             // Create a session.
             session = new VncServerSession();
             session.Connected += HandleConnected;
             session.ConnectionFailed += HandleConnectionFailed;
             session.Closed += HandleClosed;
             session.PasswordProvided += HandlePasswordProvided;
-            session.SetFramebufferSource(new VncScreenFramebufferSource("Hello World", Screen.PrimaryScreen));
-            session.PointerChanged += mouse.OnMouseUpdate;
+            session.SetFramebufferSource(new DummyFramebufferSource());
             session.Connect(client.GetStream(), options);
 
             // Let's go.

--- a/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
+++ b/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
@@ -11,12 +11,12 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\RemoteViewing.NoVncExample\DummyFramebufferSource.cs" Link="DummyFramebufferSource.cs" />
+  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/RemoteViewing/Vnc/VncPixelFormat.cs
+++ b/RemoteViewing/Vnc/VncPixelFormat.cs
@@ -74,7 +74,7 @@ namespace RemoteViewing.Vnc
                 throw new ArgumentOutOfRangeException(nameof(bitsPerPixel));
             }
 
-            if (bitDepth != 8 && bitDepth != 24)
+            if (bitDepth != 6 && bitDepth != 24)
             {
                 throw new ArgumentOutOfRangeException(nameof(bitDepth));
             }


### PR DESCRIPTION
- Listen on `127.0.0.1` instead of `0.0.0.0` so the app doesn't require elevated permissions
- Use a dummy framebuffer source instead of the screen, so it works on headless servers, too.
- Allow 6bpp pixel formats for VNC compatibility.