### PR TITLE
VncServerSession: Support using encoders

### DIFF
--- a/RemoteViewing/Vnc/Server/VncEncoder.cs
+++ b/RemoteViewing/Vnc/Server/VncEncoder.cs
@@ -34,7 +34,7 @@ namespace RemoteViewing.Vnc.Server
     /// <summary>
     /// A common base class for VNC encoders.
     /// </summary>
-    internal abstract class VncEncoder
+    public abstract class VncEncoder
     {
         /// <summary>
         /// Gets the <see cref="VncEncoder"/> protocol implemented by this <see cref="VncEncoder"/>.

--- a/RemoteViewing/Vnc/VncEncoding.cs
+++ b/RemoteViewing/Vnc/VncEncoding.cs
@@ -32,7 +32,7 @@ namespace RemoteViewing.Vnc
     /// Defines the encoding format used by the client and the server.
     /// </summary>
     /// <seealso href="http://www.iana.org/assignments/rfb/rfb.xml#rfb-4"/>
-    internal enum VncEncoding
+    public enum VncEncoding
     {
         /// <summary>
         /// The data is encoded in the raw encoding format.


### PR DESCRIPTION
The encoders are re-evaluated every time when a client sends the list of supported encoders, or changes the pixel format, and the best match is used for the remainder of the session.