### PR TITLE
Reduce logging verbosity at the Info level

### DIFF
--- a/RemoteViewing/Vnc/Server/VncMessageType.cs
+++ b/RemoteViewing/Vnc/Server/VncMessageType.cs
@@ -56,6 +56,11 @@
         /// <summary>
         /// Requests a change of desktop size.
         /// </summary>
-        SetDesktopSize = 251
+        SetDesktopSize = 251,
+
+        /// <summary>
+        /// Represents an unknown message type.
+        /// </summary>
+        Unknown = 0xFF,
     }
 }


### PR DESCRIPTION
- Log all FramebufferUpdateRequest details at Debug instead of Info level
- Avoid spamming the log at Info level when the same request is handled repeatedly.