### PR TITLE
TightEncoder: Support reading compression and quality levels.

### DIFF
--- a/RemoteViewing.Tests/RemoteViewing.Tests.csproj
+++ b/RemoteViewing.Tests/RemoteViewing.Tests.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../RemoteViewing/RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net461;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -32,7 +32,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>

--- a/RemoteViewing/Vnc/Server/IVncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/IVncServerSession.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using RemoteViewing.Logging;
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace RemoteViewing.Vnc.Server
@@ -103,6 +104,11 @@ namespace RemoteViewing.Vnc.Server
         /// Gets a lock which should be used before performing any framebuffer updates.
         /// </summary>
         object FramebufferUpdateRequestLock { get; }
+
+        /// <summary>
+        /// Gets a list of encodings supported by the client.
+        /// </summary>
+        IReadOnlyList<VncEncoding> ClientEncodings { get; }
 
         /// <summary>
         /// Starts a session with a VNC client.

--- a/RemoteViewing/Vnc/VncEncoding.cs
+++ b/RemoteViewing/Vnc/VncEncoding.cs
@@ -245,7 +245,7 @@ namespace RemoteViewing.Vnc
         /// is low compression.
         /// </summary>
         /// <seealso href="https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#compression-level-pseudo-encoding"/>
-        TightCompressionLevel3 = -252,
+        TightCompressionLevel3 = -253,
 
         /// <summary>
         /// Specifies the desired compression level, where level 9 is high compression and level 0


### PR DESCRIPTION
Tight compression levels (which influence zlib compression) and quality levels (which influence JPEG compression quality) are sent over the wire as pseudo-encodings.

Support reading these values.