### PR TITLE
Pass the rectangle region to the VNC encoders

### DIFF
--- a/RemoteViewing.Tests/Vnc/Server/RawEncoderTests.cs
+++ b/RemoteViewing.Tests/Vnc/Server/RawEncoderTests.cs
@@ -61,7 +61,7 @@ namespace RemoteViewing.Tests.Vnc.Server
             using (MemoryStream stream = new MemoryStream())
             {
                 // The encoder should write the content 'as is' to the stream.
-                encoder.Send(stream, new VncPixelFormat(), content);
+                encoder.Send(stream, new VncPixelFormat(), new VncRectangle(), content);
 
                 Assert.Equal(content, stream.ToArray());
             }

--- a/RemoteViewing.Tests/Vnc/Server/TightEncoderTests.cs
+++ b/RemoteViewing.Tests/Vnc/Server/TightEncoderTests.cs
@@ -73,7 +73,7 @@ namespace RemoteViewing.Tests.Vnc.Server
             using (MemoryStream output = new MemoryStream())
             {
                 var contents = Encoding.ASCII.GetBytes("hello, world\n");
-                encoder.Send(output, new VncPixelFormat(32, 24, 8, 0, 8, 0, 8, 0, false, true), contents);
+                encoder.Send(output, new VncPixelFormat(32, 24, 8, 0, 8, 0, 8, 0, false, true), new VncRectangle(), contents);
                 raw = output.ToArray();
             }
 
@@ -105,7 +105,7 @@ namespace RemoteViewing.Tests.Vnc.Server
             using (MemoryStream output = new MemoryStream())
             {
                 var contents = Encoding.ASCII.GetBytes("hello, world    ");
-                encoder.Send(output, new VncPixelFormat(), contents);
+                encoder.Send(output, new VncPixelFormat(), new VncRectangle(), contents);
                 raw = output.ToArray();
             }
 
@@ -138,7 +138,7 @@ namespace RemoteViewing.Tests.Vnc.Server
             using (MemoryStream output = new MemoryStream())
             {
                 var contents = new byte[] { 0x01, 0x02, 0x03, 0x04 };
-                encoder.Send(output, new VncPixelFormat(), contents);
+                encoder.Send(output, new VncPixelFormat(), new VncRectangle(), contents);
                 raw = output.ToArray();
             }
 

--- a/RemoteViewing.Tests/Vnc/Server/ZlibEncoderTests.cs
+++ b/RemoteViewing.Tests/Vnc/Server/ZlibEncoderTests.cs
@@ -66,11 +66,11 @@ namespace RemoteViewing.Tests.Vnc.Server
 
                 // Individual rectangles are compressed using the _same_ zlib stream. Let's send two
                 // rectangles to make sure this is the case.
-                encoder.Send(output, new VncPixelFormat(), contents);
+                encoder.Send(output, new VncPixelFormat(), new VncRectangle(), contents);
                 raw1 = output.ToArray();
 
                 output.SetLength(0);
-                encoder.Send(output, new VncPixelFormat(), contents);
+                encoder.Send(output, new VncPixelFormat(), new VncRectangle(), contents);
                 raw2 = output.ToArray();
             }
 

--- a/RemoteViewing/Vnc/Server/RawEncoder.cs
+++ b/RemoteViewing/Vnc/Server/RawEncoder.cs
@@ -46,7 +46,7 @@ namespace RemoteViewing.Vnc.Server
         public override VncEncoding Encoding => VncEncoding.Raw;
 
         /// <inheritdoc/>
-        public override void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents)
+        public override void Send(Stream stream, VncPixelFormat pixelFormat, VncRectangle region, byte[] contents)
         {
             stream.Write(contents, 0, contents.Length);
         }

--- a/RemoteViewing/Vnc/Server/TightEncoder.cs
+++ b/RemoteViewing/Vnc/Server/TightEncoder.cs
@@ -68,7 +68,7 @@ namespace RemoteViewing.Vnc.Server
         }
 
         /// <inheritdoc/>
-        public override void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents)
+        public override void Send(Stream stream, VncPixelFormat pixelFormat, VncRectangle rectangle, byte[] contents)
         {
             if (contents.Length < 12)
             {

--- a/RemoteViewing/Vnc/Server/VncEncoder.cs
+++ b/RemoteViewing/Vnc/Server/VncEncoder.cs
@@ -50,9 +50,12 @@ namespace RemoteViewing.Vnc.Server
         /// <param name="pixelFormat">
         /// The <see cref="VncPixelFormat"/> being used.
         /// </param>
+        /// <param name="region">
+        /// The dimesions of the rectangle.
+        /// </param>
         /// <param name="contents">
         /// The contents of the rectangle, in raw pixel format.
         /// </param>
-        public abstract void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents);
+        public abstract void Send(Stream stream, VncPixelFormat pixelFormat, VncRectangle region, byte[] contents);
     }
 }

--- a/RemoteViewing/Vnc/Server/VncServerSession.cs
+++ b/RemoteViewing/Vnc/Server/VncServerSession.cs
@@ -521,7 +521,7 @@ namespace RemoteViewing.Vnc.Server
                     this.c.SendRectangle(rectangle.Region);
                     this.c.SendUInt32BE((uint)this.Encoder.Encoding);
 
-                    this.Encoder.Send(this.c.Stream, this.clientPixelFormat, rectangle.Contents);
+                    this.Encoder.Send(this.c.Stream, this.clientPixelFormat, rectangle.Region, rectangle.Contents);
                 }
 
                 this.fbuRectangles.Clear();

--- a/RemoteViewing/Vnc/Server/ZlibEncoder.cs
+++ b/RemoteViewing/Vnc/Server/ZlibEncoder.cs
@@ -55,7 +55,7 @@ namespace RemoteViewing.Vnc.Server
         public override VncEncoding Encoding => VncEncoding.Zlib;
 
         /// <inheritdoc/>
-        public override void Send(Stream stream, VncPixelFormat pixelFormat, byte[] contents)
+        public override void Send(Stream stream, VncPixelFormat pixelFormat, VncRectangle region, byte[] contents)
         {
             this.buffer.SetLength(0);
             this.deflater.Write(contents, 0, contents.Length);


### PR DESCRIPTION
We'll need this when implementing Tight/JPEG support, as the JPEG encoder needs to be aware of the picture dimensions.