### PR TITLE
Tight/JPEG: Make sure the correct pitch is used

### DIFF
--- a/RemoteViewing/Vnc/Server/TightEncoder.cs
+++ b/RemoteViewing/Vnc/Server/TightEncoder.cs
@@ -194,7 +194,7 @@ namespace RemoteViewing.Vnc.Server
                 var jpeg = this.compressor.Compress(
                     contents.AsSpan(),
                     buffer.AsSpan(5),
-                    region.Width,
+                    0, /* auto-calculate pitch */
                     region.Width,
                     region.Height,
                     PixelFormat.Format32bppArgb,


### PR DESCRIPTION
Pitch is expressed in bytes, not pixels, so passing `rectangle.Width` was wrong. When set to `0`, libturbojpeg will auto-determine it, so let's go with that.