### PR TITLE
Implement ExtendedDesktopSize pseudo-encoding 

### DIFF
--- a/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
+++ b/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
@@ -18,11 +18,32 @@ namespace RemoteViewing.NoVncExample
 
         private VncFramebuffer framebuffer;
 
+        // The width and height of the framebuffer source.
+        // These values can be changed by the client
+        private int width = 400;
+        private int height = 400;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DummyFramebufferSource"/> class.
         /// </summary>
         public DummyFramebufferSource()
         {
+        }
+
+        /// <inheritdoc/>
+        public bool SupportsResizing => true;
+
+        /// <inheritdoc/>
+        public ExtendedDesktopSizeStatus SetDesktopSize(int width, int height)
+        {
+            if (width <= 0 || height <= 0)
+            {
+                return ExtendedDesktopSizeStatus.Prohibited;
+            }
+
+            this.width = width;
+            this.height = height;
+            return ExtendedDesktopSizeStatus.Success;
         }
 
         /// <inheritdoc/>
@@ -40,7 +61,7 @@ namespace RemoteViewing.NoVncExample
 
             var color = Color.FromArgb(this.colors[0], this.colors[1], this.colors[2]);
 
-            using (Bitmap image = new Bitmap(400, 400))
+            using (Bitmap image = new Bitmap(this.width, this.height))
             using (Graphics gfx = Graphics.FromImage(image))
             using (SolidBrush brush = new SolidBrush(color))
             using (var font = new Font(FontFamily.GenericSansSerif, 12.0f, FontStyle.Bold, GraphicsUnit.Pixel))

--- a/RemoteViewing.Tests/VncServerSessionTests.cs
+++ b/RemoteViewing.Tests/VncServerSessionTests.cs
@@ -268,8 +268,7 @@ namespace RemoteViewing.Tests
             var session = new VncServerSession();
             Assert.Collection(
                 session.Encoders,
-                (e) => Assert.IsType<TightEncoder>(e),
-                (e) => Assert.IsType<ZlibEncoder>(e));
+                (e) => Assert.IsType<TightEncoder>(e));
         }
 
         /// <summary>
@@ -282,7 +281,7 @@ namespace RemoteViewing.Tests
         /// The expected encoding.
         /// </param>
         [InlineData(false, VncEncoding.Raw)]
-        [InlineData(true, VncEncoding.Zlib)]
+        [InlineData(true, VncEncoding.Raw)]
         [Theory]
         public void HandleSetEncodingsTest(bool forceConnect, VncEncoding expectedEncoding)
         {

--- a/RemoteViewing.Windows.Forms/Server/VncScreenFramebufferSource.cs
+++ b/RemoteViewing.Windows.Forms/Server/VncScreenFramebufferSource.cs
@@ -78,6 +78,15 @@ namespace RemoteViewing.Windows.Forms.Server
             this.getScreenBounds = getBoundsCallback ?? throw new ArgumentNullException(nameof(getBoundsCallback));
         }
 
+        /// <inheritdoc/>
+        public bool SupportsResizing => false;
+
+        /// <inheritdoc/>
+        public ExtendedDesktopSizeStatus SetDesktopSize(int width, int height)
+        {
+            return ExtendedDesktopSizeStatus.Prohibited;
+        }
+
         /// <summary>
         /// Captures the screen.
         /// </summary>

--- a/RemoteViewing/Vnc/ExtendedDesktopSizeReason.cs
+++ b/RemoteViewing/Vnc/ExtendedDesktopSizeReason.cs
@@ -2,6 +2,7 @@
 /*
 RemoteViewing VNC Client/Server Library for .NET
 Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -29,35 +30,27 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace RemoteViewing.Vnc
 {
     /// <summary>
-    /// Provides a framebuffer.
+    /// Indicates the reason for a change in screen layout.
     /// </summary>
-    public interface IVncFramebufferSource
+    public enum ExtendedDesktopSizeReason : int
     {
         /// <summary>
-        /// Gets a value indicating whether the <see cref="IVncFramebufferSource"/> supports resizing.
+        /// The screen layout was changed via non-RFB means on the server. For example the server may have provided means for server-side
+        /// applications to manipulate the screen layout. This code is also used when the client sends a non-incremental FrameBufferUpdateRequest
+        /// to learn the server's current state.
         /// </summary>
-        bool SupportsResizing { get; }
+        External = 0,
 
         /// <summary>
-        /// Called when a framebuffer update is needed.
-        /// You can use this opportunity to switch framebuffers if desired.
+        /// The client receiving this message requested a change of the screen layout. The change may or may not have happened depending on server
+        /// policy or available resources. The status code in the y-position field must be used to determine which.
         /// </summary>
-        /// <returns>A framebuffer.</returns>
-        VncFramebuffer Capture();
+        Client = 1,
 
         /// <summary>
-        /// Handles a client request to resize the framebuffer.
+        /// Another client requested a change of the screen layout and the server approved it. A rectangle with this code is never sent if
+        /// the server denied the request.
         /// </summary>
-        /// <param name="width">
-        /// The width requested by the client.
-        /// </param>
-        /// <param name="height">
-        /// The height requested by the client.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ExtendedDesktopSizeStatus"/> value indicating how the <see cref="IVncFramebufferSource"/> handled
-        /// the update request.
-        /// </returns>
-        ExtendedDesktopSizeStatus SetDesktopSize(int width, int height);
+        OtherClient = 2,
     }
 }

--- a/RemoteViewing/Vnc/ExtendedDesktopSizeStatus.cs
+++ b/RemoteViewing/Vnc/ExtendedDesktopSizeStatus.cs
@@ -2,6 +2,7 @@
 /*
 RemoteViewing VNC Client/Server Library for .NET
 Copyright (c) 2013 James F. Bellinger <http://www.zer7.com/software/remoteviewing>
+Copyright (c) 2020 Quamotion bvba <http://quamotion.mobi>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -29,35 +30,28 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace RemoteViewing.Vnc
 {
     /// <summary>
-    /// Provides a framebuffer.
+    /// Indicates the status code for a change requested by a client.
     /// </summary>
-    public interface IVncFramebufferSource
+    public enum ExtendedDesktopSizeStatus : int
     {
         /// <summary>
-        /// Gets a value indicating whether the <see cref="IVncFramebufferSource"/> supports resizing.
+        /// No error
         /// </summary>
-        bool SupportsResizing { get; }
+        Success = 0,
 
         /// <summary>
-        /// Called when a framebuffer update is needed.
-        /// You can use this opportunity to switch framebuffers if desired.
+        /// Resize is administratively prohibited
         /// </summary>
-        /// <returns>A framebuffer.</returns>
-        VncFramebuffer Capture();
+        Prohibited = 1,
 
         /// <summary>
-        /// Handles a client request to resize the framebuffer.
+        /// Out of resources
         /// </summary>
-        /// <param name="width">
-        /// The width requested by the client.
-        /// </param>
-        /// <param name="height">
-        /// The height requested by the client.
-        /// </param>
-        /// <returns>
-        /// A <see cref="ExtendedDesktopSizeStatus"/> value indicating how the <see cref="IVncFramebufferSource"/> handled
-        /// the update request.
-        /// </returns>
-        ExtendedDesktopSizeStatus SetDesktopSize(int width, int height);
+        OutOfResources = 2,
+
+        /// <summary>
+        /// Invalid screen layout
+        /// </summary>
+        InvalidScreenLayout = 3,
     }
 }

--- a/RemoteViewing/Vnc/VncFramebuffer.cs
+++ b/RemoteViewing/Vnc/VncFramebuffer.cs
@@ -76,6 +76,9 @@ namespace RemoteViewing.Vnc
             this.buffer = new byte[this.Width * this.Height * this.PixelFormat.BytesPerPixel];
         }
 
+        /// <inheritdoc/>
+        public bool SupportsResizing => false;
+
         /// <summary>
         /// Gets the framebuffer name. Many VNC clients set their titlebar to this name.
         /// </summary>
@@ -184,6 +187,12 @@ namespace RemoteViewing.Vnc
                     throw new NotSupportedException();
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public ExtendedDesktopSizeStatus SetDesktopSize(int width, int height)
+        {
+            return ExtendedDesktopSizeStatus.Prohibited;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Implement ExtendedDesktopSize pseudo-encoding and handle the `SetDesktopSize` request.

The `VncServerSession` class can handle the requests at the protocol level, but leaves the actual implementation up to the `IVncFramebufferSource` class.

This change was manually tested using the noVNC client. RealVNC and TightVNC don't seem to handle this pseudo-encoding.

More advanced features, like multi-monitor support, is also not implemented.

Closes #58