### PR TITLE
Compile LibVNC for Windows and macOS

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,8 +1,106 @@
+variables:
+  # At the moment, we're building from git master.  This version has better support for (cross-)compiling
+  # for Windows.
+  # When 0.9.13 is released, we can probably start building off released versions.
+  LIBVNC_VERSION: "0.9.12"
+
 jobs:
+
+- job: native_macos
+  variables:
+    rid: osx-x64
+  pool:
+    vmImage: 'macOS-10.14'
+  steps:
+  - script: |
+      wget -nv -nc https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$(LIBVNC_VERSION).tar.gz -O LibVNCServer-$(LIBVNC_VERSION).tar.gz
+      tar xzf LibVNCServer-$(LIBVNC_VERSION).tar.gz
+    condition: false
+    displayName: Download LibVNCServer
+  - script: |
+      git clone --depth 1 https://github.com/LibVNC/libvncserver/
+    displayName: Clone LibVNCServer
+  - script: |
+      mkdir build
+      cd build
+      cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)/$(rid) ../libvncserver/
+    displayName: Configure LibVNC
+  - script: |
+      make install
+    workingDirectory: build
+    displayName: Compile LibVNC
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: libvnc
+    displayName: Publish LibVNC
+
+# Build native libvnc libraries for Windows, cross-compiled from Ubuntu
+- job: native_windows
+  strategy:
+    maxParallel: 2
+    matrix: 
+      x86:
+        arch: i686
+        targetOs: mingw32
+        rid: win7-x86
+        package: w64-i686
+      x64:
+        arch: x86_64
+        targetOs: mingw64
+        rid: win7-x64
+        package: w64-x86-64
+  pool:
+    vmImage: ubuntu-16.04
+  container:
+    image: ubuntu:18.04
+    options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
+  steps:
+  - script: |
+      /tmp/docker exec -t -u 0 ci-container \
+      sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
+    displayName: Set up sudo
+  - script: |
+      sudo apt-get install -y build-essential gcc-mingw-$(package) g++-mingw-$(package) wget git pkg-config cmake
+    displayName: Install cross-compiler
+  - script: |
+      wget -nv -nc https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$(LIBVNC_VERSION).tar.gz -O LibVNCServer-$(LIBVNC_VERSION).tar.gz
+      tar xzf LibVNCServer-$(LIBVNC_VERSION).tar.gz
+    condition: false
+    displayName: Download LibVNCServer
+  - script: |
+      git clone --depth 1 https://github.com/LibVNC/libvncserver/
+    displayName: Clone LibVNCServer
+  - script: |
+      mkdir build
+      cd build
+      cmake -DCMAKE_TOOLCHAIN_FILE=../RemoteViewing.LibVnc.NativeBinaries/$(targetOS).cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)/$(rid) ../libvncserver/
+    displayName: Configure LibVNC
+  - script: |
+      make install
+    workingDirectory: build
+    displayName: Compile LibVNC
+  - script: |
+      cp /usr/$(arch)-w64-mingw32/lib/libwinpthread-1.dll $(Build.ArtifactStagingDirectory)/$(rid)/lib
+      if [ "$(rid)" = "win7-x86" ]; then cp /usr/lib/gcc/i686-w64-mingw32/7.3-win32/libgcc_s_sjlj-1.dll $(Build.ArtifactStagingDirectory)/$(rid)/lib; fi
+      if [ "$(rid)" = "win7-x64" ]; then cp /usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_s_seh-1.dll $(Build.ArtifactStagingDirectory)/$(rid)/lib; fi
+    displayName: Copy additional files
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: libvnc
+    displayName: Publish LibVNC
+
 - job: build
   pool:
     vmImage: 'windows-latest'
+  dependsOn:
+  - native_windows
+  - native_macos
   steps:
+  - task: DownloadBuildArtifacts@0
+    inputs:
+      artifactName: libvnc
   - script: |
       mkdir $(Build.ArtifactStagingDirectory)/opencover
       mkdir $(Build.ArtifactStagingDirectory)/codecoverage

--- a/RemoteViewing.LibVNC.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
+++ b/RemoteViewing.LibVNC.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    
+    <Description>RemoteViewing.LibVnc.NativeBinaries contains the native libvnc binaries, compiled for Windows and macOS.</Description>
+    <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>
+    <Copyright>Copyright © libvncserver contributors</Copyright>
+    <Authors>Frederik Carlier</Authors>
+
+    <PackageId>Quamotion.RemoteViewing.LibVnc.NativeBinaries</PackageId>
+
+    <PackageProjectUrl>https://github.com/quamotion/remoteviewing/</PackageProjectUrl>
+    <PackageTags>VNC RFB remote desktop client server Hextile Copyrect Zlib</PackageTags>
+    <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>GPL-2.0-or-later</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/osx-x64/lib/libvncserver.dylib">
+      <PackagePath>runtimes/osx-64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/osx-x64/lib/libvncclient.dylib">
+      <PackagePath>runtimes/osx-64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/win7-x64/lib/*.dll">
+      <PackagePath>runtimes/win7-x64/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/win7-x86/lib/*.dll">
+      <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/RemoteViewing.LibVnc.NativeBinaries/mingw32.cmake
+++ b/RemoteViewing.LibVnc.NativeBinaries/mingw32.cmake
@@ -1,0 +1,27 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+set(COMPILER_PREFIX "i686-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+#SET(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+#SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+#SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+
+# here is the target environment located
+SET(USER_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps)
+SET(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX} ${USER_ROOT_PATH})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use wine for runnings tests
+set(CMAKE_CROSSCOMPILING_EMULATOR wine)

--- a/RemoteViewing.LibVnc.NativeBinaries/mingw64.cmake
+++ b/RemoteViewing.LibVnc.NativeBinaries/mingw64.cmake
@@ -1,0 +1,27 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+set(COMPILER_PREFIX "x86_64-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+#SET(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+#SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+#SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+
+# here is the target environment located
+SET(USER_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps)
+SET(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX} ${USER_ROOT_PATH})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use wine for runnings tests
+set(CMAKE_CROSSCOMPILING_EMULATOR wine)

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    
+    <Description>RemoteViewing.LibVnc is a .NET  VNC server library, which wraps around libvncserver.</Description>
+    <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>
+    <Copyright>Copyright © 2020 Quamotion bvba</Copyright>
+    <Authors>Frederik Carlier</Authors>
+
+    <PackageId>Quamotion.RemoteViewing.LibVnc</PackageId>
+
+    <PackageProjectUrl>https://github.com/quamotion/remoteviewing/</PackageProjectUrl>
+    <PackageTags>VNC RFB remote desktop client server Hextile Copyrect Zlib</PackageTags>
+    <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/RemoteViewing.sln
+++ b/RemoteViewing.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.AspNetCore", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.Tests", "RemoteViewing.Tests\RemoteViewing.Tests.csproj", "{3B608B91-5360-4536-90B6-D9CC353FCADE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.LibVnc.NativeBinaries", "RemoteViewing.LibVnc.NativeBinaries\RemoteViewing.LibVNC.NativeBinaries.csproj", "{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.LibVnc", "RemoteViewing.LibVnc\RemoteViewing.LibVnc.csproj", "{475C27D2-7296-4223-B571-1AC9089C425A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,6 +111,30 @@ Global
 		{3B608B91-5360-4536-90B6-D9CC353FCADE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{3B608B91-5360-4536-90B6-D9CC353FCADE}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B608B91-5360-4536-90B6-D9CC353FCADE}.Release|x86.Build.0 = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Debug|x86.Build.0 = Debug|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|x86.ActiveCfg = Release|Any CPU
+		{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}.Release|x86.Build.0 = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Debug|x86.Build.0 = Debug|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|x86.ActiveCfg = Release|Any CPU
+		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This is a first step to get build an implementation of RemoteViewing which wraps around the native libvnc library.

This PR adds the RemoteViewing.LibVnc.NativeBinaries package, which contains upstream libvnc compiled for Windows (32-bit and 64-bit) and macOS. Linux users are expected to acquire libvnc through their Linux distribution.

This package is GPLv2 licensed (because libvnc is GPL licensed).