### PR TITLE
Prototype the RfbScreenInfoPtr class

### DIFF
--- a/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
+++ b/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Quamotion.RemoteViewing.LibVnc.NativeBinaries" Version="*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RemoteViewing.LibVnc\RemoteViewing.LibVnc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RemoteViewing.LibVnc.Tests/RfbScreenInfoPtrTests.cs
+++ b/RemoteViewing.LibVnc.Tests/RfbScreenInfoPtrTests.cs
@@ -1,0 +1,493 @@
+#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using RemoteViewing.LibVnc.Interop;
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace RemoteViewing.LibVnc.Tests
+{
+    /// <summary>
+    /// Tests the <see cref="RfbScreenInfoPtr"/> class.
+    /// </summary>
+    public unsafe class RfbScreenInfoPtrTests
+    {
+        /// <summary>
+        /// Tests the basic layout of the <see cref="RfbScreenInfoPtr"/> class by accessing most properties.
+        /// </summary>
+        [Fact]
+        public void LayoutTest()
+        {
+            using (RfbScreenInfoPtr server = NativeMethods.rfbGetScreen(400, 300, 8, 3, 4))
+            {
+                Assert.Equal(0, server.ScaledScreenRefCount);
+                Assert.Equal(400, server.Width);
+                Assert.Equal(4 * 400, server.PaddedWidthInBytes);
+                Assert.Equal(300, server.Height);
+                Assert.Equal(32, server.Depth);
+                Assert.Equal(32, server.BitsPerPixel);
+
+                Assert.Equal(0, server.SizeInBytes);
+                Assert.Equal(0x000000u, server.BlackPixel);
+                Assert.Equal(0x000000u, server.WhitePixel);
+
+                Assert.Equal(IntPtr.Zero, server.ScreenData);
+
+                var pixelFormat = server.ServerFormat;
+                Assert.Equal(32, pixelFormat.BitsPerPixel);
+                Assert.Equal(32, pixelFormat.Depth);
+                Assert.Equal(0, pixelFormat.BigEndian);
+                Assert.Equal(1, pixelFormat.TrueColour);
+                Assert.Equal(255, pixelFormat.RedMax);
+                Assert.Equal(255, pixelFormat.GreenMax);
+                Assert.Equal(255, pixelFormat.BlueMax);
+                Assert.Equal(0, pixelFormat.RedShift);
+                Assert.Equal(8, pixelFormat.GreenShift);
+                Assert.Equal(16, pixelFormat.BlueShift);
+
+                Assert.Equal("LibVNCServer", server.DesktopName);
+                Assert.Equal(Environment.MachineName, server.ThisHost);
+                Assert.False(server.AutoPort);
+                Assert.Equal(5900, server.Port);
+
+                Assert.Equal(RfbSocketState.RFB_SOCKET_INIT, server.SocketState);
+
+                Assert.Equal(3, server.ProtocolMajorVersion);
+                Assert.Equal(8, server.ProtocolMinorVersion);
+
+                Assert.Equal(IntPtr.Zero, server.DisplayHook);
+                Assert.Equal(IntPtr.Zero, server.Framebuffer);
+                Assert.Equal(IntPtr.Zero, server.GetFileTransferPermission);
+                Assert.Equal(IntPtr.Zero, server.GetKeyboardLedStateHook);
+                Assert.NotEqual(IntPtr.Zero, server.KbdAddEvent); // rfbDefaultKbdAddEvent
+                Assert.NotEqual(IntPtr.Zero, server.KbdReleaseAllKeys); // rfbDoNothingWithClient
+                Assert.NotEqual(IntPtr.Zero, server.NewClientHook); // rfbDefaultNewClientHook
+                Assert.NotEqual(IntPtr.Zero, server.PtrAddEvent); // rfbDefaultPtrAddEvent
+                Assert.Equal(IntPtr.Zero, server.ScreenData);
+                Assert.Equal(IntPtr.Zero, server.SetServerInput);
+                Assert.Equal(IntPtr.Zero, server.SetTextChat);
+
+                Assert.False(server.IsClosed);
+                Assert.False(server.IsInvalid);
+            }
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit Windows.
+        /// </summary>
+        [Fact]
+        public void GetFieldOffsetsTest_Win64()
+        {
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(OSPlatform.Windows, is64Bit: true);
+
+            Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
+            Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
+            Assert.Equal(12, offsets[(int)RfbScreenInfoPtrField.Width]);
+            Assert.Equal(16, offsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]);
+            Assert.Equal(20, offsets[(int)RfbScreenInfoPtrField.Height]);
+            Assert.Equal(24, offsets[(int)RfbScreenInfoPtrField.Depth]);
+            Assert.Equal(28, offsets[(int)RfbScreenInfoPtrField.BitsPerPixel]);
+            Assert.Equal(32, offsets[(int)RfbScreenInfoPtrField.SizeInBytes]);
+            Assert.Equal(36, offsets[(int)RfbScreenInfoPtrField.BlackPixel]);
+            Assert.Equal(40, offsets[(int)RfbScreenInfoPtrField.WhitePixel]);
+            Assert.Equal(48, offsets[(int)RfbScreenInfoPtrField.ScreenData]);
+            Assert.Equal(56, offsets[(int)RfbScreenInfoPtrField.ServerFormat]);
+            Assert.Equal(72, offsets[(int)RfbScreenInfoPtrField.ColourMap]);
+            Assert.Equal(88, offsets[(int)RfbScreenInfoPtrField.DesktopName]);
+            Assert.Equal(96, offsets[(int)RfbScreenInfoPtrField.ThisHost]);
+            Assert.Equal(351, offsets[(int)RfbScreenInfoPtrField.AutoPort]);
+            Assert.Equal(352, offsets[(int)RfbScreenInfoPtrField.Port]);
+            Assert.Equal(360, offsets[(int)RfbScreenInfoPtrField.ListenSock]);
+            Assert.Equal(368, offsets[(int)RfbScreenInfoPtrField.MaxSock]);
+            Assert.Equal(372, offsets[(int)RfbScreenInfoPtrField.MaxFd]);
+            Assert.Equal(376, offsets[(int)RfbScreenInfoPtrField.AllFds]);
+            Assert.Equal(896, offsets[(int)RfbScreenInfoPtrField.SocketState]);
+            Assert.Equal(904, offsets[(int)RfbScreenInfoPtrField.InetdSock]);
+            Assert.Equal(912, offsets[(int)RfbScreenInfoPtrField.InetdInitDone]);
+            Assert.Equal(916, offsets[(int)RfbScreenInfoPtrField.UdpPort]);
+            Assert.Equal(920, offsets[(int)RfbScreenInfoPtrField.UdpSock]);
+            Assert.Equal(928, offsets[(int)RfbScreenInfoPtrField.UdpClient]);
+            Assert.Equal(936, offsets[(int)RfbScreenInfoPtrField.UdpSockConnected]);
+            Assert.Equal(940, offsets[(int)RfbScreenInfoPtrField.UdpRemoteAddr]);
+            Assert.Equal(956, offsets[(int)RfbScreenInfoPtrField.MaxClientWait]);
+            Assert.Equal(960, offsets[(int)RfbScreenInfoPtrField.HttpInitDone]);
+            Assert.Equal(961, offsets[(int)RfbScreenInfoPtrField.HttpEnableProxyConnect]);
+            Assert.Equal(964, offsets[(int)RfbScreenInfoPtrField.HttpPort]);
+            Assert.Equal(968, offsets[(int)RfbScreenInfoPtrField.HttpDir]);
+            Assert.Equal(976, offsets[(int)RfbScreenInfoPtrField.HttpListenSock]);
+            Assert.Equal(984, offsets[(int)RfbScreenInfoPtrField.HttpSock]);
+            Assert.Equal(992, offsets[(int)RfbScreenInfoPtrField.PasswordCheck]);
+            Assert.Equal(1000, offsets[(int)RfbScreenInfoPtrField.AuthPasswdData]);
+            Assert.Equal(1008, offsets[(int)RfbScreenInfoPtrField.AuthPasswdFirstViewOnly]);
+            Assert.Equal(1016, offsets[(int)RfbScreenInfoPtrField.DeferUpdateTime]);
+            Assert.Equal(1020, offsets[(int)RfbScreenInfoPtrField.AlwaysShared]);
+            Assert.Equal(1021, offsets[(int)RfbScreenInfoPtrField.NeverShared]);
+            Assert.Equal(1022, offsets[(int)RfbScreenInfoPtrField.DontDisconnect]);
+            Assert.Equal(1024, offsets[(int)RfbScreenInfoPtrField.ClientHead]);
+            Assert.Equal(1032, offsets[(int)RfbScreenInfoPtrField.PointerClient]);
+            Assert.Equal(1040, offsets[(int)RfbScreenInfoPtrField.CursorX]);
+            Assert.Equal(1044, offsets[(int)RfbScreenInfoPtrField.CursorY]);
+            Assert.Equal(1048, offsets[(int)RfbScreenInfoPtrField.UnderCursorBufferLen]);
+            Assert.Equal(1056, offsets[(int)RfbScreenInfoPtrField.UnderCursorBuffer]);
+            Assert.Equal(1064, offsets[(int)RfbScreenInfoPtrField.DontConvertRichCursorToXCursor]);
+            Assert.Equal(1072, offsets[(int)RfbScreenInfoPtrField.Cursor]);
+            Assert.Equal(1080, offsets[(int)RfbScreenInfoPtrField.FrameBuffer]);
+            Assert.Equal(1088, offsets[(int)RfbScreenInfoPtrField.KbdAddEvent]);
+            Assert.Equal(1096, offsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]);
+            Assert.Equal(1104, offsets[(int)RfbScreenInfoPtrField.PtrAddEvent]);
+            Assert.Equal(1112, offsets[(int)RfbScreenInfoPtrField.SetXCutText]);
+            Assert.Equal(1120, offsets[(int)RfbScreenInfoPtrField.GetCursorPtr]);
+            Assert.Equal(1128, offsets[(int)RfbScreenInfoPtrField.SetTranslateFunction]);
+            Assert.Equal(1136, offsets[(int)RfbScreenInfoPtrField.SetSingleWindow]);
+            Assert.Equal(1144, offsets[(int)RfbScreenInfoPtrField.SetServerInput]);
+            Assert.Equal(1152, offsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]);
+            Assert.Equal(1160, offsets[(int)RfbScreenInfoPtrField.SetTextChat]);
+            Assert.Equal(1168, offsets[(int)RfbScreenInfoPtrField.NewClientHook]);
+            Assert.Equal(1176, offsets[(int)RfbScreenInfoPtrField.DisplayHook]);
+            Assert.Equal(1184, offsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]);
+            Assert.Equal(1192, offsets[(int)RfbScreenInfoPtrField.CursorMutex]);
+            Assert.Equal(1200, offsets[(int)RfbScreenInfoPtrField.BackgroundLoop]);
+            Assert.Equal(1201, offsets[(int)RfbScreenInfoPtrField.IgnoreSIGPIPE]);
+            Assert.Equal(1204, offsets[(int)RfbScreenInfoPtrField.ProgressiveSliceHeight]);
+            Assert.Equal(1208, offsets[(int)RfbScreenInfoPtrField.ListenInterface]);
+            Assert.Equal(1212, offsets[(int)RfbScreenInfoPtrField.DeferPtrUpdateTime]);
+            Assert.Equal(1216, offsets[(int)RfbScreenInfoPtrField.HandleEventsEagerly]);
+            Assert.Equal(1224, offsets[(int)RfbScreenInfoPtrField.VersionString]);
+            Assert.Equal(1232, offsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]);
+            Assert.Equal(1236, offsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]);
+            Assert.Equal(1240, offsets[(int)RfbScreenInfoPtrField.PermitFileTransfer]);
+            Assert.Equal(1248, offsets[(int)RfbScreenInfoPtrField.DisplayFinishedHook]);
+            Assert.Equal(1256, offsets[(int)RfbScreenInfoPtrField.XvpHooka]);
+            Assert.Equal(1264, offsets[(int)RfbScreenInfoPtrField.Sslkeyfile]);
+            Assert.Equal(1272, offsets[(int)RfbScreenInfoPtrField.Sslcertfile]);
+            Assert.Equal(1280, offsets[(int)RfbScreenInfoPtrField.Ipv6port]);
+            Assert.Equal(1288, offsets[(int)RfbScreenInfoPtrField.Listen6Interface]);
+            Assert.Equal(1296, offsets[(int)RfbScreenInfoPtrField.Listen6Sock]);
+            Assert.Equal(1304, offsets[(int)RfbScreenInfoPtrField.Http6Port]);
+            Assert.Equal(1312, offsets[(int)RfbScreenInfoPtrField.HttpListen6Sock]);
+            Assert.Equal(1320, offsets[(int)RfbScreenInfoPtrField.SetDesktopSizeHook]);
+            Assert.Equal(1328, offsets[(int)RfbScreenInfoPtrField.NumberOfExtDesktopScreensHook]);
+            Assert.Equal(1336, offsets[(int)RfbScreenInfoPtrField.GetExtDesktopScreenHook]);
+            Assert.Equal(1344, offsets[(int)RfbScreenInfoPtrField.FdQuota]);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 32-bit Windows.
+        /// </summary>
+        [Fact]
+        public void GetFieldOffsetsTest_Win32()
+        {
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(OSPlatform.Windows, is64Bit: false);
+
+            Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
+            Assert.Equal(4, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
+            Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.Width]);
+            Assert.Equal(12, offsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]);
+            Assert.Equal(16, offsets[(int)RfbScreenInfoPtrField.Height]);
+            Assert.Equal(20, offsets[(int)RfbScreenInfoPtrField.Depth]);
+            Assert.Equal(24, offsets[(int)RfbScreenInfoPtrField.BitsPerPixel]);
+            Assert.Equal(28, offsets[(int)RfbScreenInfoPtrField.SizeInBytes]);
+            Assert.Equal(32, offsets[(int)RfbScreenInfoPtrField.BlackPixel]);
+            Assert.Equal(36, offsets[(int)RfbScreenInfoPtrField.WhitePixel]);
+            Assert.Equal(40, offsets[(int)RfbScreenInfoPtrField.ScreenData]);
+            Assert.Equal(44, offsets[(int)RfbScreenInfoPtrField.ServerFormat]);
+            Assert.Equal(60, offsets[(int)RfbScreenInfoPtrField.ColourMap]);
+            Assert.Equal(72, offsets[(int)RfbScreenInfoPtrField.DesktopName]);
+            Assert.Equal(76, offsets[(int)RfbScreenInfoPtrField.ThisHost]);
+            Assert.Equal(331, offsets[(int)RfbScreenInfoPtrField.AutoPort]);
+            Assert.Equal(332, offsets[(int)RfbScreenInfoPtrField.Port]);
+            Assert.Equal(336, offsets[(int)RfbScreenInfoPtrField.ListenSock]);
+            Assert.Equal(340, offsets[(int)RfbScreenInfoPtrField.MaxSock]);
+            Assert.Equal(344, offsets[(int)RfbScreenInfoPtrField.MaxFd]);
+            Assert.Equal(348, offsets[(int)RfbScreenInfoPtrField.AllFds]);
+            Assert.Equal(608, offsets[(int)RfbScreenInfoPtrField.SocketState]);
+            Assert.Equal(612, offsets[(int)RfbScreenInfoPtrField.InetdSock]);
+            Assert.Equal(616, offsets[(int)RfbScreenInfoPtrField.InetdInitDone]);
+            Assert.Equal(620, offsets[(int)RfbScreenInfoPtrField.UdpPort]);
+            Assert.Equal(624, offsets[(int)RfbScreenInfoPtrField.UdpSock]);
+            Assert.Equal(628, offsets[(int)RfbScreenInfoPtrField.UdpClient]);
+            Assert.Equal(632, offsets[(int)RfbScreenInfoPtrField.UdpSockConnected]);
+            Assert.Equal(636, offsets[(int)RfbScreenInfoPtrField.UdpRemoteAddr]);
+            Assert.Equal(652, offsets[(int)RfbScreenInfoPtrField.MaxClientWait]);
+            Assert.Equal(656, offsets[(int)RfbScreenInfoPtrField.HttpInitDone]);
+            Assert.Equal(657, offsets[(int)RfbScreenInfoPtrField.HttpEnableProxyConnect]);
+            Assert.Equal(660, offsets[(int)RfbScreenInfoPtrField.HttpPort]);
+            Assert.Equal(664, offsets[(int)RfbScreenInfoPtrField.HttpDir]);
+            Assert.Equal(668, offsets[(int)RfbScreenInfoPtrField.HttpListenSock]);
+            Assert.Equal(672, offsets[(int)RfbScreenInfoPtrField.HttpSock]);
+            Assert.Equal(676, offsets[(int)RfbScreenInfoPtrField.PasswordCheck]);
+            Assert.Equal(680, offsets[(int)RfbScreenInfoPtrField.AuthPasswdData]);
+            Assert.Equal(684, offsets[(int)RfbScreenInfoPtrField.AuthPasswdFirstViewOnly]);
+            Assert.Equal(692, offsets[(int)RfbScreenInfoPtrField.DeferUpdateTime]);
+            Assert.Equal(696, offsets[(int)RfbScreenInfoPtrField.AlwaysShared]);
+            Assert.Equal(697, offsets[(int)RfbScreenInfoPtrField.NeverShared]);
+            Assert.Equal(698, offsets[(int)RfbScreenInfoPtrField.DontDisconnect]);
+            Assert.Equal(700, offsets[(int)RfbScreenInfoPtrField.ClientHead]);
+            Assert.Equal(704, offsets[(int)RfbScreenInfoPtrField.PointerClient]);
+            Assert.Equal(708, offsets[(int)RfbScreenInfoPtrField.CursorX]);
+            Assert.Equal(712, offsets[(int)RfbScreenInfoPtrField.CursorY]);
+            Assert.Equal(716, offsets[(int)RfbScreenInfoPtrField.UnderCursorBufferLen]);
+            Assert.Equal(720, offsets[(int)RfbScreenInfoPtrField.UnderCursorBuffer]);
+            Assert.Equal(724, offsets[(int)RfbScreenInfoPtrField.DontConvertRichCursorToXCursor]);
+            Assert.Equal(728, offsets[(int)RfbScreenInfoPtrField.Cursor]);
+            Assert.Equal(732, offsets[(int)RfbScreenInfoPtrField.FrameBuffer]);
+            Assert.Equal(736, offsets[(int)RfbScreenInfoPtrField.KbdAddEvent]);
+            Assert.Equal(740, offsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]);
+            Assert.Equal(744, offsets[(int)RfbScreenInfoPtrField.PtrAddEvent]);
+            Assert.Equal(748, offsets[(int)RfbScreenInfoPtrField.SetXCutText]);
+            Assert.Equal(752, offsets[(int)RfbScreenInfoPtrField.GetCursorPtr]);
+            Assert.Equal(756, offsets[(int)RfbScreenInfoPtrField.SetTranslateFunction]);
+            Assert.Equal(760, offsets[(int)RfbScreenInfoPtrField.SetSingleWindow]);
+            Assert.Equal(764, offsets[(int)RfbScreenInfoPtrField.SetServerInput]);
+            Assert.Equal(768, offsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]);
+            Assert.Equal(772, offsets[(int)RfbScreenInfoPtrField.SetTextChat]);
+            Assert.Equal(776, offsets[(int)RfbScreenInfoPtrField.NewClientHook]);
+            Assert.Equal(780, offsets[(int)RfbScreenInfoPtrField.DisplayHook]);
+            Assert.Equal(784, offsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]);
+            Assert.Equal(788, offsets[(int)RfbScreenInfoPtrField.CursorMutex]);
+            Assert.Equal(792, offsets[(int)RfbScreenInfoPtrField.BackgroundLoop]);
+            Assert.Equal(793, offsets[(int)RfbScreenInfoPtrField.IgnoreSIGPIPE]);
+            Assert.Equal(796, offsets[(int)RfbScreenInfoPtrField.ProgressiveSliceHeight]);
+            Assert.Equal(800, offsets[(int)RfbScreenInfoPtrField.ListenInterface]);
+            Assert.Equal(804, offsets[(int)RfbScreenInfoPtrField.DeferPtrUpdateTime]);
+            Assert.Equal(808, offsets[(int)RfbScreenInfoPtrField.HandleEventsEagerly]);
+            Assert.Equal(812, offsets[(int)RfbScreenInfoPtrField.VersionString]);
+            Assert.Equal(816, offsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]);
+            Assert.Equal(820, offsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]);
+            Assert.Equal(824, offsets[(int)RfbScreenInfoPtrField.PermitFileTransfer]);
+            Assert.Equal(828, offsets[(int)RfbScreenInfoPtrField.DisplayFinishedHook]);
+            Assert.Equal(832, offsets[(int)RfbScreenInfoPtrField.XvpHooka]);
+            Assert.Equal(836, offsets[(int)RfbScreenInfoPtrField.Sslkeyfile]);
+            Assert.Equal(840, offsets[(int)RfbScreenInfoPtrField.Sslcertfile]);
+            Assert.Equal(844, offsets[(int)RfbScreenInfoPtrField.Ipv6port]);
+            Assert.Equal(848, offsets[(int)RfbScreenInfoPtrField.Listen6Interface]);
+            Assert.Equal(852, offsets[(int)RfbScreenInfoPtrField.Listen6Sock]);
+            Assert.Equal(856, offsets[(int)RfbScreenInfoPtrField.Http6Port]);
+            Assert.Equal(860, offsets[(int)RfbScreenInfoPtrField.HttpListen6Sock]);
+            Assert.Equal(864, offsets[(int)RfbScreenInfoPtrField.SetDesktopSizeHook]);
+            Assert.Equal(868, offsets[(int)RfbScreenInfoPtrField.NumberOfExtDesktopScreensHook]);
+            Assert.Equal(872, offsets[(int)RfbScreenInfoPtrField.GetExtDesktopScreenHook]);
+            Assert.Equal(876, offsets[(int)RfbScreenInfoPtrField.FdQuota]);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit Linux.
+        /// </summary>
+        [Fact]
+        public void GetFieldOffsetsTest_Linux64()
+        {
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(OSPlatform.Linux, is64Bit: true);
+
+            Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
+            Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
+            Assert.Equal(12, offsets[(int)RfbScreenInfoPtrField.Width]);
+            Assert.Equal(16, offsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]);
+            Assert.Equal(20, offsets[(int)RfbScreenInfoPtrField.Height]);
+            Assert.Equal(24, offsets[(int)RfbScreenInfoPtrField.Depth]);
+            Assert.Equal(28, offsets[(int)RfbScreenInfoPtrField.BitsPerPixel]);
+            Assert.Equal(32, offsets[(int)RfbScreenInfoPtrField.SizeInBytes]);
+            Assert.Equal(36, offsets[(int)RfbScreenInfoPtrField.BlackPixel]);
+            Assert.Equal(40, offsets[(int)RfbScreenInfoPtrField.WhitePixel]);
+            Assert.Equal(48, offsets[(int)RfbScreenInfoPtrField.ScreenData]);
+            Assert.Equal(56, offsets[(int)RfbScreenInfoPtrField.ServerFormat]);
+            Assert.Equal(72, offsets[(int)RfbScreenInfoPtrField.ColourMap]);
+            Assert.Equal(88, offsets[(int)RfbScreenInfoPtrField.DesktopName]);
+            Assert.Equal(96, offsets[(int)RfbScreenInfoPtrField.ThisHost]);
+            Assert.Equal(351, offsets[(int)RfbScreenInfoPtrField.AutoPort]);
+            Assert.Equal(352, offsets[(int)RfbScreenInfoPtrField.Port]);
+            Assert.Equal(356, offsets[(int)RfbScreenInfoPtrField.ListenSock]);
+            Assert.Equal(360, offsets[(int)RfbScreenInfoPtrField.MaxSock]);
+            Assert.Equal(364, offsets[(int)RfbScreenInfoPtrField.MaxFd]);
+            Assert.Equal(368, offsets[(int)RfbScreenInfoPtrField.AllFds]);
+            Assert.Equal(496, offsets[(int)RfbScreenInfoPtrField.SocketState]);
+            Assert.Equal(500, offsets[(int)RfbScreenInfoPtrField.InetdSock]);
+            Assert.Equal(504, offsets[(int)RfbScreenInfoPtrField.InetdInitDone]);
+            Assert.Equal(508, offsets[(int)RfbScreenInfoPtrField.UdpPort]);
+            Assert.Equal(512, offsets[(int)RfbScreenInfoPtrField.UdpSock]);
+            Assert.Equal(520, offsets[(int)RfbScreenInfoPtrField.UdpClient]);
+            Assert.Equal(528, offsets[(int)RfbScreenInfoPtrField.UdpSockConnected]);
+            Assert.Equal(532, offsets[(int)RfbScreenInfoPtrField.UdpRemoteAddr]);
+            Assert.Equal(548, offsets[(int)RfbScreenInfoPtrField.MaxClientWait]);
+            Assert.Equal(552, offsets[(int)RfbScreenInfoPtrField.HttpInitDone]);
+            Assert.Equal(553, offsets[(int)RfbScreenInfoPtrField.HttpEnableProxyConnect]);
+            Assert.Equal(556, offsets[(int)RfbScreenInfoPtrField.HttpPort]);
+            Assert.Equal(560, offsets[(int)RfbScreenInfoPtrField.HttpDir]);
+            Assert.Equal(568, offsets[(int)RfbScreenInfoPtrField.HttpListenSock]);
+            Assert.Equal(572, offsets[(int)RfbScreenInfoPtrField.HttpSock]);
+            Assert.Equal(576, offsets[(int)RfbScreenInfoPtrField.PasswordCheck]);
+            Assert.Equal(584, offsets[(int)RfbScreenInfoPtrField.AuthPasswdData]);
+            Assert.Equal(592, offsets[(int)RfbScreenInfoPtrField.AuthPasswdFirstViewOnly]);
+            Assert.Equal(600, offsets[(int)RfbScreenInfoPtrField.DeferUpdateTime]);
+            Assert.Equal(604, offsets[(int)RfbScreenInfoPtrField.AlwaysShared]);
+            Assert.Equal(605, offsets[(int)RfbScreenInfoPtrField.NeverShared]);
+            Assert.Equal(606, offsets[(int)RfbScreenInfoPtrField.DontDisconnect]);
+            Assert.Equal(608, offsets[(int)RfbScreenInfoPtrField.ClientHead]);
+            Assert.Equal(616, offsets[(int)RfbScreenInfoPtrField.PointerClient]);
+            Assert.Equal(624, offsets[(int)RfbScreenInfoPtrField.CursorX]);
+            Assert.Equal(628, offsets[(int)RfbScreenInfoPtrField.CursorY]);
+            Assert.Equal(632, offsets[(int)RfbScreenInfoPtrField.UnderCursorBufferLen]);
+            Assert.Equal(640, offsets[(int)RfbScreenInfoPtrField.UnderCursorBuffer]);
+            Assert.Equal(648, offsets[(int)RfbScreenInfoPtrField.DontConvertRichCursorToXCursor]);
+            Assert.Equal(656, offsets[(int)RfbScreenInfoPtrField.Cursor]);
+            Assert.Equal(664, offsets[(int)RfbScreenInfoPtrField.FrameBuffer]);
+            Assert.Equal(672, offsets[(int)RfbScreenInfoPtrField.KbdAddEvent]);
+            Assert.Equal(680, offsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]);
+            Assert.Equal(688, offsets[(int)RfbScreenInfoPtrField.PtrAddEvent]);
+            Assert.Equal(696, offsets[(int)RfbScreenInfoPtrField.SetXCutText]);
+            Assert.Equal(704, offsets[(int)RfbScreenInfoPtrField.GetCursorPtr]);
+            Assert.Equal(712, offsets[(int)RfbScreenInfoPtrField.SetTranslateFunction]);
+            Assert.Equal(720, offsets[(int)RfbScreenInfoPtrField.SetSingleWindow]);
+            Assert.Equal(728, offsets[(int)RfbScreenInfoPtrField.SetServerInput]);
+            Assert.Equal(736, offsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]);
+            Assert.Equal(744, offsets[(int)RfbScreenInfoPtrField.SetTextChat]);
+            Assert.Equal(752, offsets[(int)RfbScreenInfoPtrField.NewClientHook]);
+            Assert.Equal(760, offsets[(int)RfbScreenInfoPtrField.DisplayHook]);
+            Assert.Equal(768, offsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]);
+            Assert.Equal(776, offsets[(int)RfbScreenInfoPtrField.CursorMutex]);
+            Assert.Equal(816, offsets[(int)RfbScreenInfoPtrField.BackgroundLoop]);
+            Assert.Equal(817, offsets[(int)RfbScreenInfoPtrField.IgnoreSIGPIPE]);
+            Assert.Equal(820, offsets[(int)RfbScreenInfoPtrField.ProgressiveSliceHeight]);
+            Assert.Equal(824, offsets[(int)RfbScreenInfoPtrField.ListenInterface]);
+            Assert.Equal(828, offsets[(int)RfbScreenInfoPtrField.DeferPtrUpdateTime]);
+            Assert.Equal(832, offsets[(int)RfbScreenInfoPtrField.HandleEventsEagerly]);
+            Assert.Equal(840, offsets[(int)RfbScreenInfoPtrField.VersionString]);
+            Assert.Equal(848, offsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]);
+            Assert.Equal(852, offsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]);
+            Assert.Equal(856, offsets[(int)RfbScreenInfoPtrField.PermitFileTransfer]);
+            Assert.Equal(864, offsets[(int)RfbScreenInfoPtrField.DisplayFinishedHook]);
+            Assert.Equal(872, offsets[(int)RfbScreenInfoPtrField.XvpHooka]);
+            Assert.Equal(880, offsets[(int)RfbScreenInfoPtrField.Sslkeyfile]);
+            Assert.Equal(888, offsets[(int)RfbScreenInfoPtrField.Sslcertfile]);
+            Assert.Equal(896, offsets[(int)RfbScreenInfoPtrField.Ipv6port]);
+            Assert.Equal(904, offsets[(int)RfbScreenInfoPtrField.Listen6Interface]);
+            Assert.Equal(912, offsets[(int)RfbScreenInfoPtrField.Listen6Sock]);
+            Assert.Equal(916, offsets[(int)RfbScreenInfoPtrField.Http6Port]);
+            Assert.Equal(920, offsets[(int)RfbScreenInfoPtrField.HttpListen6Sock]);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit OSX.
+        /// </summary>
+        [Fact]
+        public void GetFieldOffsetsTest_OSX64()
+        {
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(OSPlatform.OSX, is64Bit: true);
+
+            Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
+            Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
+            Assert.Equal(12, offsets[(int)RfbScreenInfoPtrField.Width]);
+            Assert.Equal(16, offsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]);
+            Assert.Equal(20, offsets[(int)RfbScreenInfoPtrField.Height]);
+            Assert.Equal(24, offsets[(int)RfbScreenInfoPtrField.Depth]);
+            Assert.Equal(28, offsets[(int)RfbScreenInfoPtrField.BitsPerPixel]);
+            Assert.Equal(32, offsets[(int)RfbScreenInfoPtrField.SizeInBytes]);
+            Assert.Equal(36, offsets[(int)RfbScreenInfoPtrField.BlackPixel]);
+            Assert.Equal(40, offsets[(int)RfbScreenInfoPtrField.WhitePixel]);
+            Assert.Equal(48, offsets[(int)RfbScreenInfoPtrField.ScreenData]);
+            Assert.Equal(56, offsets[(int)RfbScreenInfoPtrField.ServerFormat]);
+            Assert.Equal(72, offsets[(int)RfbScreenInfoPtrField.ColourMap]);
+            Assert.Equal(88, offsets[(int)RfbScreenInfoPtrField.DesktopName]);
+            Assert.Equal(96, offsets[(int)RfbScreenInfoPtrField.ThisHost]);
+            Assert.Equal(351, offsets[(int)RfbScreenInfoPtrField.AutoPort]);
+            Assert.Equal(352, offsets[(int)RfbScreenInfoPtrField.Port]);
+            Assert.Equal(356, offsets[(int)RfbScreenInfoPtrField.ListenSock]);
+            Assert.Equal(360, offsets[(int)RfbScreenInfoPtrField.MaxSock]);
+            Assert.Equal(364, offsets[(int)RfbScreenInfoPtrField.MaxFd]);
+            Assert.Equal(368, offsets[(int)RfbScreenInfoPtrField.AllFds]);
+            Assert.Equal(496, offsets[(int)RfbScreenInfoPtrField.SocketState]);
+            Assert.Equal(500, offsets[(int)RfbScreenInfoPtrField.InetdSock]);
+            Assert.Equal(504, offsets[(int)RfbScreenInfoPtrField.InetdInitDone]);
+            Assert.Equal(508, offsets[(int)RfbScreenInfoPtrField.UdpPort]);
+            Assert.Equal(512, offsets[(int)RfbScreenInfoPtrField.UdpSock]);
+            Assert.Equal(520, offsets[(int)RfbScreenInfoPtrField.UdpClient]);
+            Assert.Equal(528, offsets[(int)RfbScreenInfoPtrField.UdpSockConnected]);
+            Assert.Equal(532, offsets[(int)RfbScreenInfoPtrField.UdpRemoteAddr]);
+            Assert.Equal(548, offsets[(int)RfbScreenInfoPtrField.MaxClientWait]);
+            Assert.Equal(552, offsets[(int)RfbScreenInfoPtrField.HttpInitDone]);
+            Assert.Equal(553, offsets[(int)RfbScreenInfoPtrField.HttpEnableProxyConnect]);
+            Assert.Equal(556, offsets[(int)RfbScreenInfoPtrField.HttpPort]);
+            Assert.Equal(560, offsets[(int)RfbScreenInfoPtrField.HttpDir]);
+            Assert.Equal(568, offsets[(int)RfbScreenInfoPtrField.HttpListenSock]);
+            Assert.Equal(572, offsets[(int)RfbScreenInfoPtrField.HttpSock]);
+            Assert.Equal(576, offsets[(int)RfbScreenInfoPtrField.PasswordCheck]);
+            Assert.Equal(584, offsets[(int)RfbScreenInfoPtrField.AuthPasswdData]);
+            Assert.Equal(592, offsets[(int)RfbScreenInfoPtrField.AuthPasswdFirstViewOnly]);
+            Assert.Equal(600, offsets[(int)RfbScreenInfoPtrField.DeferUpdateTime]);
+            Assert.Equal(604, offsets[(int)RfbScreenInfoPtrField.AlwaysShared]);
+            Assert.Equal(605, offsets[(int)RfbScreenInfoPtrField.NeverShared]);
+            Assert.Equal(606, offsets[(int)RfbScreenInfoPtrField.DontDisconnect]);
+            Assert.Equal(608, offsets[(int)RfbScreenInfoPtrField.ClientHead]);
+            Assert.Equal(616, offsets[(int)RfbScreenInfoPtrField.PointerClient]);
+            Assert.Equal(624, offsets[(int)RfbScreenInfoPtrField.CursorX]);
+            Assert.Equal(628, offsets[(int)RfbScreenInfoPtrField.CursorY]);
+            Assert.Equal(632, offsets[(int)RfbScreenInfoPtrField.UnderCursorBufferLen]);
+            Assert.Equal(640, offsets[(int)RfbScreenInfoPtrField.UnderCursorBuffer]);
+            Assert.Equal(648, offsets[(int)RfbScreenInfoPtrField.DontConvertRichCursorToXCursor]);
+            Assert.Equal(656, offsets[(int)RfbScreenInfoPtrField.Cursor]);
+            Assert.Equal(664, offsets[(int)RfbScreenInfoPtrField.FrameBuffer]);
+            Assert.Equal(672, offsets[(int)RfbScreenInfoPtrField.KbdAddEvent]);
+            Assert.Equal(680, offsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]);
+            Assert.Equal(688, offsets[(int)RfbScreenInfoPtrField.PtrAddEvent]);
+            Assert.Equal(696, offsets[(int)RfbScreenInfoPtrField.SetXCutText]);
+            Assert.Equal(704, offsets[(int)RfbScreenInfoPtrField.GetCursorPtr]);
+            Assert.Equal(712, offsets[(int)RfbScreenInfoPtrField.SetTranslateFunction]);
+            Assert.Equal(720, offsets[(int)RfbScreenInfoPtrField.SetSingleWindow]);
+            Assert.Equal(728, offsets[(int)RfbScreenInfoPtrField.SetServerInput]);
+            Assert.Equal(736, offsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]);
+            Assert.Equal(744, offsets[(int)RfbScreenInfoPtrField.SetTextChat]);
+            Assert.Equal(752, offsets[(int)RfbScreenInfoPtrField.NewClientHook]);
+            Assert.Equal(760, offsets[(int)RfbScreenInfoPtrField.DisplayHook]);
+            Assert.Equal(768, offsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]);
+            Assert.Equal(776, offsets[(int)RfbScreenInfoPtrField.CursorMutex]);
+            Assert.Equal(840, offsets[(int)RfbScreenInfoPtrField.BackgroundLoop]);
+            Assert.Equal(841, offsets[(int)RfbScreenInfoPtrField.IgnoreSIGPIPE]);
+            Assert.Equal(844, offsets[(int)RfbScreenInfoPtrField.ProgressiveSliceHeight]);
+            Assert.Equal(848, offsets[(int)RfbScreenInfoPtrField.ListenInterface]);
+            Assert.Equal(852, offsets[(int)RfbScreenInfoPtrField.DeferPtrUpdateTime]);
+            Assert.Equal(856, offsets[(int)RfbScreenInfoPtrField.HandleEventsEagerly]);
+            Assert.Equal(864, offsets[(int)RfbScreenInfoPtrField.VersionString]);
+            Assert.Equal(872, offsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]);
+            Assert.Equal(876, offsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]);
+            Assert.Equal(880, offsets[(int)RfbScreenInfoPtrField.PermitFileTransfer]);
+            Assert.Equal(888, offsets[(int)RfbScreenInfoPtrField.DisplayFinishedHook]);
+            Assert.Equal(896, offsets[(int)RfbScreenInfoPtrField.XvpHooka]);
+            Assert.Equal(904, offsets[(int)RfbScreenInfoPtrField.Sslkeyfile]);
+            Assert.Equal(912, offsets[(int)RfbScreenInfoPtrField.Sslcertfile]);
+            Assert.Equal(920, offsets[(int)RfbScreenInfoPtrField.Ipv6port]);
+            Assert.Equal(928, offsets[(int)RfbScreenInfoPtrField.Listen6Interface]);
+            Assert.Equal(936, offsets[(int)RfbScreenInfoPtrField.Listen6Sock]);
+            Assert.Equal(940, offsets[(int)RfbScreenInfoPtrField.Http6Port]);
+            Assert.Equal(944, offsets[(int)RfbScreenInfoPtrField.HttpListen6Sock]);
+            Assert.Equal(952, offsets[(int)RfbScreenInfoPtrField.SetDesktopSizeHook]);
+            Assert.Equal(960, offsets[(int)RfbScreenInfoPtrField.NumberOfExtDesktopScreensHook]);
+            Assert.Equal(968, offsets[(int)RfbScreenInfoPtrField.GetExtDesktopScreenHook]);
+            Assert.Equal(976, offsets[(int)RfbScreenInfoPtrField.FdQuota]);
+        }
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/NativeLayout.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLayout.cs
@@ -1,0 +1,436 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Provides methods for working with native struct layouts.
+    /// </summary>
+    internal static class NativeLayout
+    {
+        /// <summary>
+        /// The type sizes and alignments of the types used by libvncserver on 64-bit Windows platforms.
+        /// </summary>
+        private static readonly int[][] Win64 =
+            new int[][]
+            {
+                // type sizes
+                new int[]
+                {
+                    0, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    16, // PixelFormat,
+                    16, // ColourMap,
+                    255, // Char_255,
+                    1, // Bool,
+                    8, // Socket,
+                    520, // FdSet,
+                    4, // SocketState,
+                    16, // SockAddrIn,
+                    8, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    8, // Timeval,
+                    30000, // Byte_30000,
+                    112, // z_stream_s,
+                    4 * 112, // zsStruct_4,
+                    4, // Bool_4,
+                    16, // Int_4,
+                    24, // rfbFileTransferData,
+                    8, // pthread_cond_t,
+                    4 * 64 * 64, // int zywrleBuf[rfbZRLETileWidth * rfbZRLETileHeight],
+                    8, // Int_2,
+                    16, // Byte_CHALLENGESIZE,
+                    8, // PthreadT,
+                },
+
+                // alignments
+                new int[]
+                {
+                    1, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    1, // PixelFormat,
+                    4, // ColourMap,
+                    1, // Char_255,
+                    1, // Bool,
+                    8, // Socket,
+                    1, // FdSet,
+                    4, // SocketState,
+                    4, // SockAddrIn,
+                    8, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    1, // Timeval,
+                    1, // Byte_30000,
+                    1, // z_stream_s,
+                    8, // zsStruct_4,
+                    1, // Bool_4,
+                    1, // Int_4,
+                    1, // rfbFileTransferData,
+                    1, // pthread_cond_t,
+                    1, // Int_ZRLE,
+                    1, // Int_2,
+                    1, // Byte_CHALLENGESIZE,
+                    1, // PthreadT,
+                },
+            };
+
+        /// <summary>
+        /// The type sizes and alignments of the types used by libvncserver on 32-bit Windows platforms.
+        /// </summary>
+        private static readonly int[][] Win32 =
+            new int[][]
+            {
+                // type sizes
+                new int[]
+                {
+                    0, // Skip,
+                    4, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    16, // PixelFormat,
+                    12, // ColourMap,
+                    255, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    260, // FdSet,
+                    4, // SocketState,
+                    16, // SockAddrIn,
+                    4, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    8, // Timeval,
+                    30000, // Byte_30000,
+                    112, // z_stream_s,
+                    4 * 112, // zsStruct_4,
+                    4, // Bool_4,
+                    16, // Int_4,
+                    24, // rfbFileTransferData,
+                    4, // pthread_cond_t,
+                    4 * 64 * 64, // int zywrleBuf[rfbZRLETileWidth * rfbZRLETileHeight],
+                    8, // Int_2,
+                    16, // Byte_CHALLENGESIZE,
+                    4, // PthreadT,
+                },
+
+                // alignments
+                new int[]
+                {
+                    1, // Skip,
+                    4, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    1, // PixelFormat,
+                    4, // ColourMap,
+                    1, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    1, // FdSet,
+                    4, // SocketState,
+                    4, // SockAddrIn,
+                    4, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    1, // Timeval,
+                    1, // Byte_30000,
+                    1, // z_stream_s,
+                    8, // zsStruct_4,
+                    1, // Bool_4,
+                    1, // Int_4,
+                    1, // rfbFileTransferData,
+                    1, // pthread_cond_t,
+                    1, // Int_ZRLE,
+                    1, // Int_2,
+                    1, // Byte_CHALLENGESIZE,
+                    1, // PthreadT,
+                },
+            };
+
+        /// <summary>
+        /// The type sizes and alignments of the types used by libvncserver on 64-bit Linux platforms.
+        /// </summary>
+        private static readonly int[][] Linux64 =
+            new int[][]
+            {
+                // type sizes
+                new int[]
+                {
+                    0, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    16, // PixelFormat,
+                    16, // ColourMap,
+                    255, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    128, // FdSet,
+                    4, // SocketState,
+                    16, // SockAddrIn,
+                    40, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    16, // Timeval,
+                    30000, // Byte_30000,
+                    112, // z_stream_s,
+                    4 * 112, // zsStruct_4,
+                    4, // Bool_4,
+                    16, // Int_4,
+                    24, // rfbFileTransferData,
+                    48, // pthread_cond_t,
+                    4 * 64 * 64, // int zywrleBuf[rfbZRLETileWidth * rfbZRLETileHeight],
+                    8, // Int_2,
+                    16, // Byte_CHALLENGESIZE,
+                    8, // PthreadT,
+                },
+
+                // alignments
+                new int[]
+                {
+                    1, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    1, // PixelFormat,
+                    4, // ColourMap,
+                    1, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    1, // FdSet,
+                    4, // SocketState,
+                    4, // SockAddrIn,
+                    8, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    1, // Timeval,
+                    1, // Byte_30000,
+                    1, // z_stream_s,
+                    8, // zsStruct_4,
+                    1, // Bool_4,
+                    1, // Int_4,
+                    1, // rfbFileTransferData,
+                    1, // pthread_cond_t,
+                    1, // Int_ZRLE,
+                    1, // Int_2,
+                    1, // Byte_CHALLENGESIZE,
+                    1, // PthreadT,
+                },
+            };
+
+        /// <summary>
+        /// The type sizes and alignments of the types used by libvncserver on 64-bit OSX platforms.
+        /// </summary>
+        private static readonly int[][] OSX64 =
+            new int[][]
+            {
+                // type sizes
+                new int[]
+                {
+                    0, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    16, // PixelFormat,
+                    16, // ColourMap,
+                    255, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    128, // FdSet,
+                    4, // SocketState,
+                    16, // SockAddrIn,
+                    64, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    16, // Timeval,
+                    30000, // Byte_30000,
+                    112, // z_stream_s,
+                    4 * 112, // zsStruct_4,
+                    4, // Bool_4,
+                    16, // Int_4,
+                    24, // rfbFileTransferData,
+                    48, // pthread_cond_t,
+                    4 * 64 * 64, // int zywrleBuf[rfbZRLETileWidth * rfbZRLETileHeight],
+                    8, // Int_2,
+                    16, // Byte_CHALLENGESIZE,
+                    8, // PthreadT,
+                },
+
+                // alignments
+                new int[]
+                {
+                    1, // Skip,
+                    8, // IntPtr,
+                    4, // Int,
+                    4, // Pixel,
+                    1, // PixelFormat,
+                    4, // ColourMap,
+                    1, // Char_255,
+                    1, // Bool,
+                    4, // Socket,
+                    1, // FdSet,
+                    4, // SocketState,
+                    4, // SockAddrIn,
+                    8, // Mutex,
+                    4, // InAddrT,
+                    4, // Float,
+
+                    1, // Timeval,
+                    1, // Byte_30000,
+                    1, // z_stream_s,
+                    8, // zsStruct_4,
+                    1, // Bool_4,
+                    1, // Int_4,
+                    1, // rfbFileTransferData,
+                    1, // pthread_cond_t,
+                    1, // Int_ZRLE,
+                    1, // Int_2,
+                    1, // Byte_CHALLENGESIZE,
+                    1, // PthreadT,
+                },
+            };
+
+        /// <summary>
+        /// Gets the current <see cref="OSPlatform"/>.
+        /// </summary>
+        /// <returns>
+        /// The current <see cref="OSPlatform"/>.
+        /// </returns>
+        public static OSPlatform GetOSPlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return OSPlatform.Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSPlatform.Linux;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSPlatform.OSX;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        /// <summary>
+        /// Gets the offsets of a list of fields.
+        /// </summary>
+        /// <param name="fieldTypes">
+        /// An array which contains the type of each field.
+        /// </param>
+        /// <param name="platform">
+        /// The platform for which to determine the offset.
+        /// </param>
+        /// <param name="is64Bit">
+        /// A value indicating whether the platform is 32-bit or 64-bit.
+        /// </param>
+        /// <returns>
+        /// An array which contains the offsets of the fields.
+        /// </returns>
+        public static int[] GetFieldOffsets(RfbType[] fieldTypes, OSPlatform platform, bool is64Bit)
+        {
+            int[] value = new int[fieldTypes.Length];
+            int[] typeAlignment;
+            int[] typeSizes;
+
+            if (platform == OSPlatform.Windows)
+            {
+                if (is64Bit)
+                {
+                    typeSizes = Win64[0];
+                    typeAlignment = Win64[1];
+                }
+                else
+                {
+                    typeSizes = Win32[0];
+                    typeAlignment = Win32[1];
+                }
+            }
+            else if (platform == OSPlatform.Linux)
+            {
+                if (!is64Bit)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(platform));
+                }
+
+                typeSizes = Linux64[0];
+                typeAlignment = Linux64[1];
+            }
+            else if (platform == OSPlatform.OSX)
+            {
+                if (!is64Bit)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(platform));
+                }
+
+                typeSizes = OSX64[0];
+                typeAlignment = OSX64[1];
+            }
+            else
+            {
+                throw new ArgumentOutOfRangeException(nameof(platform));
+            }
+
+            int offset = 0;
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                // align
+                int alignment = typeAlignment[(int)fieldTypes[i]];
+                int ret = offset % alignment;
+
+                if (ret != 0)
+                {
+                    offset += alignment - ret;
+                }
+
+                value[i] = offset;
+                offset += typeSizes[(int)fieldTypes[i]];
+            }
+
+            return value;
+        }
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -1,0 +1,328 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using RemoteViewing.Vnc;
+using System;
+using System.Runtime.InteropServices;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Provides access to <c>libvncserver</c> methods.
+    /// </summary>
+    public static unsafe class NativeMethods
+    {
+        /// <summary>
+        /// The name of the libvncserver library.
+        /// </summary>
+        public const string LibraryName = "libvncserver";
+
+        /// <summary>
+        /// The calling convention used by the libvncserver library.
+        /// </summary>
+        public const CallingConvention LibraryCallingConvention = CallingConvention.Cdecl;
+
+        /// <summary>
+        /// A delegate which is invoked when a new client connects to a server.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RfbNewClientAction"/> which determines how to proceed.
+        /// </returns>
+        public delegate RfbNewClientAction RfbNewClientHookPtr(IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked when a keyboard event occurs.
+        /// </summary>
+        /// <param name="down">
+        /// A value indicating whether the key is currently down.
+        /// </param>
+        /// <param name="keySym">
+        /// The key for which the event occurs.
+        /// </param>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        public delegate void RfbKbdAddEventProcPtr(byte down, KeySym keySym, IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked when an mouse event occurs.
+        /// </summary>
+        /// <param name="buttonMask">
+        /// A bit mask of pressed mouse buttons, in X11 convention.
+        /// </param>
+        /// <param name="x">
+        /// The x coordinate of the point at which the touch occurred.
+        /// </param>
+        /// <param name="y">
+        /// The y coordinate of the point at which the touch occurred.
+        /// </param>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        public delegate void RfbPtrAddEventProcPtr(int buttonMask, int x, int y, IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked when a client disconnects.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        public delegate void ClientGoneHookPtr(IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked when a client requests a framebuffer update.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        /// <param name="furMsg">
+        /// The framebuffer update request message.
+        /// </param>
+        public delegate void ClientFramebufferUpdateRequestHookPtr(IntPtr cl, IntPtr /*rfbFramebufferUpdateRequestMsg*/ furMsg);
+
+        /// <summary>
+        /// A delegate which is invoked to determine whether the X11 server permits input from the
+        /// local user.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        /// <param name="status">
+        /// <c>0</c> when the X11 user does not permit input from the local user; otherwise,
+        /// <c>1</c>.
+        /// </param>
+        public delegate void rfbSetServerInputProcPtr(IntPtr cl, int status);
+
+        /// <summary>
+        /// A delegate which is invoked to determine whether to allow or deny file transfers. The default is
+        /// to deny file transfers. It is called when a client initiates a connection to determine if it is permitted.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        /// <returns>
+        /// <c>0</c> when file transfers are denied; otherwise, <c>1</c>.
+        /// </returns>
+        public delegate int rfbFileTransferPermitted(IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked to handle textchag messages.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        /// <param name="length">
+        /// The length of the textchat message.
+        /// </param>
+        /// <param name="message">
+        /// The textchat message.
+        /// </param>
+        public delegate void rfbSetTextChat(IntPtr cl, int length, char* message);
+
+        /// <summary>
+        /// A delegate which is invoked just before a frame buffer update.
+        /// </summary>
+        /// <param name="cl">
+        /// The server structure.
+        /// </param>
+        public delegate void rfbDisplayHookPtr(IntPtr cl);
+
+        /// <summary>
+        /// A delegate which is invoked to get the caps/num/scroll states of the X server.
+        /// </summary>
+        /// <param name="screen">
+        /// The server structure.
+        /// </param>
+        /// <returns>
+        /// The caps/num/scroll states of the X server.
+        /// </returns>
+        public delegate int rfbGetKeyboardLedStateHookPtr(IntPtr screen);
+
+        /// <summary>
+        /// Initialises a server structure.
+        /// </summary>
+        /// <param name="argc">
+        /// The number of command-line arguments.
+        /// </param>
+        /// <param name="argv">
+        /// The command-line arguments passed to libvncserver.
+        /// </param>
+        /// <param name="width">
+        /// The width of the screen, in pixels.
+        /// </param>
+        /// <param name="height">
+        /// The height of the screen, in pixels.
+        /// </param>
+        /// <param name="bitsPerSample">
+        /// The number of bits per sample.
+        /// </param>
+        /// <param name="samplesPerPixel">
+        /// The number of samples per pixel.
+        /// </param>
+        /// <param name="bytesPerPixel">
+        /// The number of bytes per pixel.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RfbScreenInfoPtr"/> which represents the server structure.
+        /// </returns>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbGetScreen")]
+        public static extern RfbScreenInfoPtr rfbGetScreen(ref int argc, char** argv, int width, int height, int bitsPerSample, int samplesPerPixel, int bytesPerPixel);
+
+        /// <summary>
+        /// Initialises a server structure.
+        /// </summary>
+        /// <param name="width">
+        /// The width of the screen, in pixels.
+        /// </param>
+        /// <param name="height">
+        /// The height of the screen, in pixels.
+        /// </param>
+        /// <param name="bitsPerSample">
+        /// The number of bits per sample.
+        /// </param>
+        /// <param name="samplesPerPixel">
+        /// The number of samples per pixel.
+        /// </param>
+        /// <param name="bytesPerPixel">
+        /// The number of bytes per pixel.
+        /// </param>
+        /// <returns>
+        /// A <see cref="RfbScreenInfoPtr"/> which represents the server structure.
+        /// </returns>
+        public static RfbScreenInfoPtr rfbGetScreen(int width, int height, int bitsPerSample, int samplesPerPixel, int bytesPerPixel)
+        {
+            int count = 0;
+            return rfbGetScreen(ref count, null, width, height, bitsPerSample, samplesPerPixel, bytesPerPixel);
+        }
+
+        // TODO: Enable ZRLE
+
+        /// <summary>
+        /// Initialize the server.
+        /// </summary>
+        /// <param name="rfbScreen">
+        /// The server structure to initialize.
+        /// </param>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbInitServerWithPthreadsButWithoutZRLE")]
+        public static extern void rfbInitServer(RfbScreenInfoPtr rfbScreen);
+
+        /// <summary>
+        /// Updates a server structure to use a new framebuffer.
+        /// </summary>
+        /// <param name="rfbScreen">
+        /// The server structure.
+        /// </param>
+        /// <param name="framebuffer">
+        /// The new framebuffer.
+        /// </param>
+        /// <param name="width">
+        /// The width of the screen, in pixels.
+        /// </param>
+        /// <param name="height">
+        /// The height of the screen, in pixels.
+        /// </param>
+        /// <param name="bitsPerSample">
+        /// The number of bits per sample.
+        /// </param>
+        /// <param name="samplesPerPixel">
+        /// The number of samples per pixel.
+        /// </param>
+        /// <param name="bytesPerPixel">
+        /// The number of bytes per pixel.
+        /// </param>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbNewFramebuffer")]
+        public static extern void rfbNewFramebuffer(RfbScreenInfoPtr rfbScreen, void* framebuffer, int width, int height, int bitsPerSample, int samplesPerPixel, int bytesPerPixel);
+
+        /// <summary>
+        /// Cleans up a server structure.
+        /// </summary>
+        /// <param name="screen">
+        /// The server structure to clean up.
+        /// </param>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbScreenCleanup")]
+        public static extern void rfbScreenCleanup(IntPtr screen);
+
+        /// <summary>
+        /// Marks a rectangle as modified.
+        /// </summary>
+        /// <param name="rfbScreen">
+        /// The server structure.
+        /// </param>
+        /// <param name="x1">
+        /// The x coordinate of the lower-left corner of the rectangle.
+        /// </param>
+        /// <param name="y1">
+        /// The y coordinate of the lower-left corner of the rectangle.
+        /// </param>
+        /// <param name="x2">
+        /// The x coordinate of the upper-right corner of the rectangle.
+        /// </param>
+        /// <param name="y2">
+        /// The y coordinate of the upper-right corner of the rectangle.
+        /// </param>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbMarkRectAsModified")]
+        public static extern void rfbMarkRectAsModified(RfbScreenInfoPtr rfbScreen, int x1, int y1, int x2, int y2);
+
+        /// <summary>
+        /// Runs the VNC event loop.
+        /// </summary>
+        /// <param name="screenInfo">
+        /// The server for which to run the event loop.
+        /// </param>
+        /// <param name="usec">
+        /// The number of microseconds the select on the fds waits.
+        /// If you are using the event loop, set this to some value > 0, so the
+        /// server doesn't get a high load just by listening.
+        /// </param>
+        /// <param name="runInBackground">
+        /// A value indicating whether to run as a background thread or not.
+        /// </param>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbRunEventLoop")]
+        public static extern void rfbRunEventLoop(RfbScreenInfoPtr screenInfo, long usec, byte runInBackground);
+
+        /// <summary>
+        /// Processes VNC server events.
+        /// </summary>
+        /// <param name="screenInfo">
+        /// The server for which to process events.
+        /// </param>
+        /// <param name="usec">
+        /// The number of microseconds the select on the fds waits.
+        /// If you are using the event loop, set this to some value > 0, so the
+        /// server doesn't get a high load just by listening.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if an update was pending.
+        /// </returns>
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbProcessEvents")]
+        public static extern byte rfbProcessEvents(RfbScreenInfoPtr screenInfo, long usec);
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbNewClientAction.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbNewClientAction.cs
@@ -1,0 +1,51 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Specifies the action to take when a new client attempts to connect.
+    /// </summary>
+    public enum RfbNewClientAction
+    {
+        /// <summary>
+        /// Accept the client.
+        /// </summary>
+        RFB_CLIENT_ACCEPT,
+
+        /// <summary>
+        /// Put the client on hold.
+        /// </summary>
+        RFB_CLIENT_ON_HOLD,
+
+        /// <summary>
+        /// Refuse the connection.
+        /// </summary>
+        RFB_CLIENT_REFUSE,
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbPixelFormat.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbPixelFormat.cs
@@ -1,0 +1,107 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System.Runtime.InteropServices;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// A structure used to specify the pixel format.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct RfbPixelFormat
+    {
+        /// <summary>
+        /// The number of bits per pixel. Valid values are 8, 16, or 32.
+        /// </summary>
+        public byte BitsPerPixel;
+
+        /// <summary>
+        /// Gets the depth of the pixel. Value values are 8 to 32.
+        /// </summary>
+        public byte Depth;
+
+        /// <summary>
+        /// A value indicating whether multi-byte pixels are interpreted as big endian.
+        /// </summary>
+        public byte BigEndian;
+
+        /// <summary>
+        /// A value indicating whether the pixels are true colors (e.g. RGB values).
+        /// </summary>
+        /// <remarks>
+        /// If the value is <see langword="false"/>, a colour map is used to convert
+        /// pixels to RGB.
+        /// </remarks>
+        public byte TrueColour;
+
+        /* the following fields are only meaningful if trueColour is true */
+
+        /// <summary>
+        /// The maximum red value (= <c>2^n - 1</c> where <c>n</c> is the number
+        /// of bits used for red). This value is always in big endian order.
+        /// </summary>
+        public ushort RedMax;
+
+        /// <summary>
+        /// The maximum green value (= <c>2^n - 1</c> where <c>n</c> is the number
+        /// of bits used for green). This value is always in big endian order.
+        /// </summary>
+        public ushort GreenMax;
+
+        /// <summary>
+        /// The maximum blue value (= <c>2^n - 1</c> where <c>n</c> is the number
+        /// of bits used for blue). This value is always in big endian order.
+        /// </summary>
+        public ushort BlueMax;
+
+        /// <summary>
+        /// The number of shifts needed to get the red value in a pixel to the least
+        /// significant bit.
+        /// </summary>
+        public byte RedShift;
+
+        /// <summary>
+        /// The number of shifts needed to get the green value in a pixel to the least
+        /// significant bit.
+        /// </summary>
+        public byte GreenShift;
+
+        /// <summary>
+        /// The number of shifts needed to get the blue value in a pixel to the least
+        /// significant bit.
+        /// </summary>
+        public byte BlueShift;
+
+        /// <summary>
+        /// Three bytes of padding to align the struct size.
+        /// </summary>
+        private byte pad1;
+        private ushort pad2;
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.Fields.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.Fields.cs
@@ -1,0 +1,138 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Contains logic to determine the offset of individual fields of the <see cref="RfbScreenInfoPtr"/> class.
+    /// </summary>
+    public partial class RfbScreenInfoPtr
+    {
+        private static readonly RfbType[] FieldTypes = new RfbType[]
+        {
+            RfbType.Pointer, // scaledScreenNext
+            RfbType.Int, // scaledScreenRefCount
+            RfbType.Int, // width
+            RfbType.Int, // paddedWidthInBytes
+            RfbType.Int, // height
+            RfbType.Int, // depth
+            RfbType.Int, // bitsPerPixel
+            RfbType.Int, // sizeInBytes
+            RfbType.Pixel, // blackPixel
+            RfbType.Pixel, // whitePixel,
+            RfbType.Pointer, // screenData,
+            RfbType.PixelFormat, // serverFormat,
+            RfbType.ColourMap, // colourMap,
+            RfbType.Pointer, // desktopName,
+            RfbType.Char_255, // thisHost,
+            RfbType.Bool, // autoPort,
+            RfbType.Int, // port,
+            RfbType.Socket, // listenSock,
+            RfbType.Int, // maxSock,
+            RfbType.Int, // maxFd,
+            RfbType.FdSet, // allFds,
+            RfbType.SocketState, // socketState,
+            RfbType.Socket, // inetdSock,
+            RfbType.Bool, // inetdInitDone,
+            RfbType.Int, // udpPort,
+            RfbType.Socket, // udpSock,
+            RfbType.Pointer, // udpClient,
+            RfbType.Bool, // udpSockConnected,
+            RfbType.SockAddrIn, // udpRemoteAddr,
+            RfbType.Int, // maxClientWait,
+            RfbType.Bool, // httpInitDone,
+            RfbType.Bool, // httpEnableProxyConnect,
+            RfbType.Int, // httpPort,
+            RfbType.Pointer, // httpDir,
+            RfbType.Socket, // httpListenSock,
+            RfbType.Socket, // httpSock,
+            RfbType.Pointer, // passwordCheck,
+            RfbType.Pointer, // authPasswdData,
+            RfbType.Int, // authPasswdFirstViewOnly,
+            RfbType.Int, // maxRectsPerUpdate,
+            RfbType.Int, // deferUpdateTime,
+            // RfbType.Skip, // screen
+            RfbType.Bool, // alwaysShared,
+            RfbType.Bool, // neverShared,
+            RfbType.Bool, // dontDisconnect,
+            RfbType.Pointer, // clientHead,
+            RfbType.Pointer, // pointerClient,
+            RfbType.Int, // cursorX,
+            RfbType.Int, // cursorY,
+            RfbType.Int, // underCursorBufferLen,
+            RfbType.Pointer, // underCursorBuffer,
+            RfbType.Bool, // dontConvertRichCursorToXCursor,
+            RfbType.Pointer, // cursor,
+            RfbType.Pointer, // frameBuffer,
+            RfbType.Pointer, // kbdAddEvent,
+            RfbType.Pointer, // kbdReleaseAllKeys,
+            RfbType.Pointer, // ptrAddEvent,
+            RfbType.Pointer, // setXCutText,
+            RfbType.Pointer, // getCursorPtr,
+            RfbType.Pointer, // setTranslateFunction,
+            RfbType.Pointer, // setSingleWindow,
+            RfbType.Pointer, // setServerInput,
+            RfbType.Pointer, // getFileTransferPermission,
+            RfbType.Pointer, // setTextChat,
+            RfbType.Pointer, // newClientHook,
+            RfbType.Pointer, // displayHook,
+            RfbType.Pointer, // getKeyboardLedStateHook,
+            RfbType.Mutex, // cursorMutex,
+            RfbType.Bool, // backgroundLoop,
+            RfbType.Bool, // ignoreSIGPIPE,
+            RfbType.Int, // progressiveSliceHeight,
+            RfbType.InAddrT, // listenInterface,
+            RfbType.Int, // deferPtrUpdateTime,
+            RfbType.Bool, // handleEventsEagerly,
+            RfbType.Pointer, // versionString,
+            RfbType.Int, // protocolMajorVersion,
+            RfbType.Int, // protocolMinorVersion,
+            RfbType.Bool, // permitFileTransfer,
+            RfbType.Pointer, // displayFinishedHook,
+            RfbType.Pointer, // xvpHooka,
+            RfbType.Pointer, // sslkeyfile,
+            RfbType.Pointer, // sslcertfile,
+            RfbType.Int, // ipv6port,
+            RfbType.Pointer, // listen6Interface,
+            RfbType.Socket, // listen6Sock,
+            RfbType.Int, // http6Port,
+            RfbType.Socket, // httpListen6Sock,
+            RfbType.Pointer, // setDesktopSizeHook,
+            RfbType.Pointer, // numberOfExtDesktopScreensHook,
+            RfbType.Pointer, // getExtDesktopScreenHook,
+            RfbType.Float, // fdQuota,
+        };
+
+        private static readonly int[] FieldOffsets = GetFieldOffsets(NativeLayout.GetOSPlatform(), Environment.Is64BitProcess);
+
+        public static int[] GetFieldOffsets(OSPlatform platform, bool is64Bit) => NativeLayout.GetFieldOffsets(FieldTypes, platform, is64Bit);
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.cs
@@ -1,0 +1,340 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Represents a VNC server.
+    /// </summary>
+    /// <seealso href="https://github.com/LibVNC/libvncserver/blob/master/rfb/rfb.h#L263"/>
+    public unsafe partial class RfbScreenInfoPtr : SafeHandleMinusOneIsInvalid
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RfbScreenInfoPtr"/> class.
+        /// </summary>
+        public RfbScreenInfoPtr()
+            : this(true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RfbScreenInfoPtr"/> class,
+        /// specifying whether the handle is to be reliably released.
+        /// </summary>
+        /// <param name="ownsHandle">
+        /// <see langword="true"/> to reliably release the handle during the finalization phase; <see langword="false"/> to prevent
+        /// reliable release (not recommended).
+        /// </param>
+        public RfbScreenInfoPtr(bool ownsHandle)
+            : base(ownsHandle)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating the number of clients for the current scaled screen.
+        /// </summary>
+        public int ScaledScreenRefCount
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the width of the screen, in pixels.
+        /// </summary>
+        public int Width
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Width]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Width], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the aligned width of the screen, in bytes.
+        /// </summary>
+        public int PaddedWidthInBytes
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the height of the screen, in bytes.
+        /// </summary>
+        public int Height
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Height]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Height], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the color depth.
+        /// </summary>
+        public int Depth
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Depth]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Depth], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of bits per pixel.
+        /// </summary>
+        public int BitsPerPixel
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.BitsPerPixel]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.BitsPerPixel], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the number of bytes per pixel.
+        /// </summary>
+        public int SizeInBytes
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SizeInBytes]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SizeInBytes], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the value for a black pixel.
+        /// </summary>
+        public uint BlackPixel
+        {
+            get { return (uint)Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.BlackPixel]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.BlackPixel], (int)value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the value for a white pixel.
+        /// </summary>
+        public uint WhitePixel
+        {
+            get { return (uint)Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.WhitePixel]); }
+            set { Marshal.WriteInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.WhitePixel], (int)value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a reference to a screen-specific data structure.
+        /// </summary>
+        public IntPtr ScreenData
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ScreenData]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ScreenData], value); }
+        }
+
+        /// <summary>
+        /// Gets the pixel format.
+        /// </summary>
+        public RfbPixelFormat ServerFormat
+        {
+            get { return Marshal.PtrToStructure<RfbPixelFormat>(this.handle + FieldOffsets[(int)RfbScreenInfoPtrField.ServerFormat]); }
+        }
+
+        /// <summary>
+        /// Gets the name of the desktop.
+        /// </summary>
+        public string DesktopName
+        {
+            get
+            {
+                var desktopName = (sbyte**)((sbyte*)this.handle.ToPointer() + FieldOffsets[(int)RfbScreenInfoPtrField.DesktopName]);
+                return new string(*desktopName);
+            }
+        }
+
+        /// <summary>
+        /// Gets the name of the current host.
+        /// </summary>
+        public string ThisHost
+        {
+            get
+            {
+                sbyte* thisName = (sbyte*)this.handle.ToPointer() + FieldOffsets[(int)RfbScreenInfoPtrField.ThisHost];
+                return new string(thisName);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether to use an auto-selected port.
+        /// </summary>
+        public bool AutoPort
+        {
+            get { return this.GetBool(FieldOffsets[(int)RfbScreenInfoPtrField.AutoPort]); }
+        }
+
+        /// <summary>
+        /// Gets the TCP port used.
+        /// </summary>
+        public int Port
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.Port]); }
+        }
+
+        /// <summary>
+        /// Gets the state of the TCP socket.
+        /// </summary>
+        public RfbSocketState SocketState
+        {
+            // 496 on Unix
+            get { return (RfbSocketState)Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SocketState]); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to the framebuffer.
+        /// </summary>
+        public IntPtr Framebuffer
+        {
+            // 664 on Unix
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.FrameBuffer]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.FrameBuffer], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.RfbKbdAddEventProcPtr"/> delegate which is invoked
+        /// when a keyboard event occurs.
+        /// </summary>
+        public IntPtr KbdAddEvent
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.KbdAddEvent]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.KbdAddEvent], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.release"/>.
+        /// </summary>
+        public IntPtr KbdReleaseAllKeys
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.RfbPtrAddEventProcPtr"/> delegate which is invoked
+        /// when a mouse event occurs.
+        /// </summary>
+        public IntPtr PtrAddEvent
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.PtrAddEvent]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.PtrAddEvent], value); }
+        }
+
+        // GetCursorPtr. This could be used to make an animated cursor.
+        // SetTranslateFunction. If you insist on colour maps or something more obscure, you have to implement this. Default is a trueColour mapping.
+        // SetSingleWindow. If x==1 and y==1 then set the whole display, else find the window underneath x and y and set the framebuffer to the dimensions of that window.
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.rfbSetServerInputProcPtr"/> delegate which is invoked to determine
+        /// whether the X11 server accepts input from the local user.
+        /// </summary>
+        public IntPtr SetServerInput
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SetServerInput]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SetServerInput], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.rfbFileTransferPermitted"/> delegate which is invoked to determine
+        /// whether file transfers are permitted.
+        /// </summary>
+        public IntPtr GetFileTransferPermission
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.rfbSetTextChat"/> delegate which is invoked to handle
+        /// textchat messages.
+        /// </summary>
+        public IntPtr SetTextChat
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SetTextChat]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.SetTextChat], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.RfbNewClientHookPtr"/> delegate which is invoked when
+        /// a new client connects.
+        /// </summary>
+        public IntPtr NewClientHook
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.NewClientHook]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.NewClientHook], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.rfbDisplayHookPtr"/> delegate which is invoked
+        /// just before a frame buffer update.
+        /// </summary>
+        public IntPtr DisplayHook
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.DisplayHook]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.DisplayHook], value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a pointer to a <see cref="NativeMethods.rfbGetKeyboardLedStateHookPtr"/> delegate which is invoked
+        /// when the server wants to determine the state of the caps/num/scroll leds of the server.
+        /// </summary>
+        public IntPtr GetKeyboardLedStateHook
+        {
+            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]); }
+            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook], value); }
+        }
+
+        /// <summary>
+        /// Gets the major version number of the RFB protocol in use.
+        /// </summary>
+        public int ProtocolMajorVersion
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]); }
+        }
+
+        /// <summary>
+        /// Gets the minor version number of the RFB protocol in use.
+        /// </summary>
+        public int ProtocolMinorVersion
+        {
+            get { return Marshal.ReadInt32(this.handle, FieldOffsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]); }
+        }
+
+        /// <inheritdoc/>
+        protected override bool ReleaseHandle()
+        {
+            NativeMethods.rfbScreenCleanup(this.handle);
+            return true;
+        }
+
+        private bool GetBool(int offset)
+        {
+            return Marshal.ReadByte(this.handle, offset) == 1;
+        }
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtrField.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtrField.cs
@@ -1,0 +1,129 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Represents the various fields of the <see cref="RfbScreenInfoPtr"/> struct.
+    /// </summary>
+    public enum RfbScreenInfoPtrField
+    {
+#pragma warning disable SA1602 // Enumeration items should be documented
+        ScaledScreenNext,
+        ScaledScreenRefCount,
+        Width,
+        PaddedWidthInBytes,
+        Height,
+        Depth,
+        BitsPerPixel,
+        SizeInBytes,
+        BlackPixel,
+        WhitePixel,
+        ScreenData,
+        ServerFormat,
+        ColourMap,
+        DesktopName,
+        ThisHost,
+        AutoPort,
+        Port,
+        ListenSock,
+        MaxSock,
+        MaxFd,
+        AllFds,
+        SocketState,
+        InetdSock,
+        InetdInitDone,
+        UdpPort,
+        UdpSock,
+        UdpClient,
+        UdpSockConnected,
+        UdpRemoteAddr,
+        MaxClientWait,
+        HttpInitDone,
+        HttpEnableProxyConnect,
+        HttpPort,
+        HttpDir,
+        HttpListenSock,
+        HttpSock,
+        PasswordCheck,
+        AuthPasswdData,
+        AuthPasswdFirstViewOnly,
+        MaxRectsPerUpdate,
+        DeferUpdateTime,
+        AlwaysShared,
+        NeverShared,
+        DontDisconnect,
+        ClientHead,
+        PointerClient,
+        CursorX,
+        CursorY,
+        UnderCursorBufferLen,
+        UnderCursorBuffer,
+        DontConvertRichCursorToXCursor,
+        Cursor,
+        FrameBuffer,
+        KbdAddEvent,
+        KbdReleaseAllKeys,
+        PtrAddEvent,
+        SetXCutText,
+        GetCursorPtr,
+        SetTranslateFunction,
+        SetSingleWindow,
+        SetServerInput,
+        GetFileTransferPermission,
+        SetTextChat,
+        NewClientHook,
+        DisplayHook,
+        GetKeyboardLedStateHook,
+        CursorMutex,
+        BackgroundLoop,
+        IgnoreSIGPIPE,
+        ProgressiveSliceHeight,
+        ListenInterface,
+        DeferPtrUpdateTime,
+        HandleEventsEagerly,
+        VersionString,
+        ProtocolMajorVersion,
+        ProtocolMinorVersion,
+        PermitFileTransfer,
+        DisplayFinishedHook,
+        XvpHooka,
+        Sslkeyfile,
+        Sslcertfile,
+        Ipv6port,
+        Listen6Interface,
+        Listen6Sock,
+        Http6Port,
+        HttpListen6Sock,
+        SetDesktopSizeHook,
+        NumberOfExtDesktopScreensHook,
+        GetExtDesktopScreenHook,
+        FdQuota,
+#pragma warning restore SA1602 // Enumeration items should be documented
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbSocketState.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbSocketState.cs
@@ -1,0 +1,51 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// The state of a RFB socket.
+    /// </summary>
+    public enum RfbSocketState
+    {
+        /// <summary>
+        /// The socket is initializing.
+        /// </summary>
+        RFB_SOCKET_INIT,
+
+        /// <summary>
+        /// The socket is ready.
+        /// </summary>
+        RFB_SOCKET_READY,
+
+        /// <summary>
+        /// The socket has shut down.
+        /// </summary>
+        RFB_SOCKET_SHUTDOWN,
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/RfbType.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbType.cs
@@ -1,0 +1,171 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Represents a type used by libvnc.
+    /// </summary>
+    internal enum RfbType
+    {
+        /// <summary>
+        /// The field is not used and shoudl be skipped. Can be used to 'undefine' fields.
+        /// </summary>
+        Skip,
+
+        /// <summary>
+        /// The field is a pointer.
+        /// </summary>
+        Pointer,
+
+        /// <summary>
+        /// The field is a 32-bit integer.
+        /// </summary>
+        Int,
+
+        /// <summary>
+        /// The field is of type <c>rfbPixel</c>.
+        /// </summary>
+        Pixel,
+
+        /// <summary>
+        /// The field is of type <c>rfbPixelFormat</c>.
+        /// </summary>
+        PixelFormat,
+
+        /// <summary>
+        /// The field is of type <c>rfbColourMap</c>.
+        /// </summary>
+        ColourMap,
+
+        /// <summary>
+        /// The field is a character array of 255 chars.
+        /// </summary>
+        Char_255,
+
+        /// <summary>
+        /// The field is of type <c>rfbBool</c>.
+        /// </summary>
+        Bool,
+
+        /// <summary>
+        /// The field is of type <c>rfbSocket</c>.
+        /// </summary>
+        Socket,
+
+        /// <summary>
+        /// The field is of type <c>fd_set</c>.
+        /// </summary>
+        FdSet,
+
+        /// <summary>
+        /// The field is of type <c>rfbSocketState</c>.
+        /// </summary>
+        SocketState,
+
+        /// <summary>
+        /// The field is of type <c>sockaddr_in</c>.
+        /// </summary>
+        SockAddrIn,
+
+        /// <summary>
+        /// The field is of type <c>MUTEX()</c>.
+        /// </summary>
+        Mutex,
+
+        /// <summary>
+        /// The field is of type <c>in_addr_t</c>.
+        /// </summary>
+        InAddrT,
+
+        /// <summary>
+        /// The field is of type float.
+        /// </summary>
+        Float,
+
+        /// <summary>
+        /// The field is of type <c>timeval</c>.
+        /// </summary>
+        Timeval,
+
+        /// <summary>
+        /// The field consists of 30000 bytes.
+        /// </summary>
+        Byte_30000,
+
+        /// <summary>
+        /// The field is of type <c>z_stream</c>.
+        /// </summary>
+        Z_stream_s,
+
+        /// <summary>
+        /// The field is an array of 4 <c>z_stream</c> objects.
+        /// </summary>
+        ZsStruct_4,
+
+        /// <summary>
+        /// The field is an array of 4 booleans.
+        /// </summary>
+        Bool_4,
+
+        /// <summary>
+        /// The field is an array of 4 integers.
+        /// </summary>
+        Int_4,
+
+        /// <summary>
+        /// The field is of type <c>rfbFileTransferData</c>.
+        /// </summary>
+        RfbFileTransferData,
+
+        /// <summary>
+        /// The field is of type <c>pthread_cond_t</c>.
+        /// </summary>
+        Pthread_cond_t,
+
+        /// <summary>
+        /// The field is an array of [rfbZRLETileWidth * rfbZRLETileHeight] integers.
+        /// </summary>
+        Int_ZRLE,
+
+        /// <summary>
+        /// The field is an array of 2 integers.
+        /// </summary>
+        Int_2,
+
+        /// <summary>
+        /// The field is an array of CHALLENGESIZE bytes.
+        /// </summary>
+        Byte_CHALLENGESIZE,
+
+        /// <summary>
+        /// The field is of type <c>pthread_t</c>.
+        /// </summary>
+        PthreadT,
+    }
+}

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -18,11 +18,17 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj" />
   </ItemGroup>
 </Project>

--- a/RemoteViewing.sln
+++ b/RemoteViewing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing", "RemoteViewing\RemoteViewing.csproj", "{89569346-2C71-4A85-99B9-D3EB71FDE87A}"
 EndProject
@@ -17,9 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.AspNetCore", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.Tests", "RemoteViewing.Tests\RemoteViewing.Tests.csproj", "{3B608B91-5360-4536-90B6-D9CC353FCADE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.LibVnc.NativeBinaries", "RemoteViewing.LibVnc.NativeBinaries\RemoteViewing.LibVNC.NativeBinaries.csproj", "{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.LibVNC.NativeBinaries", "RemoteViewing.LibVnc.NativeBinaries\RemoteViewing.LibVNC.NativeBinaries.csproj", "{F2DF2AC7-B0C1-4CCC-ACA5-919DB4BA106D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoteViewing.LibVnc", "RemoteViewing.LibVnc\RemoteViewing.LibVnc.csproj", "{475C27D2-7296-4223-B571-1AC9089C425A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.LibVnc", "RemoteViewing.LibVnc\RemoteViewing.LibVnc.csproj", "{475C27D2-7296-4223-B571-1AC9089C425A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteViewing.LibVnc.Tests", "RemoteViewing.LibVnc.Tests\RemoteViewing.LibVnc.Tests.csproj", "{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -135,6 +137,18 @@ Global
 		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|x86.ActiveCfg = Release|Any CPU
 		{475C27D2-7296-4223-B571-1AC9089C425A}.Release|x86.Build.0 = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Debug|x86.Build.0 = Debug|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|x86.ActiveCfg = Release|Any CPU
+		{D2B0C132-9E6C-4FB4-AF01-69B43D55EF62}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a first draft implementation of the `RfbScreenInfoPtr` class which provides access to the `rfbScreenInfo` struct.

The `rfbScreenInfo` struct is a complex struct, with:
- Fields which may or may not be available based on preprocessor variables
- Fields which have different types depending on the target OS (e.g. sockets on Windows vs. Unix)
- Different alignment rules depending on OS and bitness

Because of this:
- The struct is not represented as a `struct` on the .NET side, but rather as a `SafeHandle` (essentially a wrapper around an `IntPtr`)
- Access to the various field is implemented via properties

The offsets of the individual fields are determined _at runtime_ based on the target OS and bitness. The `RfbScreenInfoPtr` maintains an array which defines the types of all the fields, from which we can determine their offsets. This is done in a static initializer. Other approaches may be viable, too.

This PR also includes a first wave of P/Invoke method declarations.