### PR TITLE
Publish code coverage using .trx format, run all unit tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -133,33 +133,18 @@ jobs:
   - task: DownloadBuildArtifacts@0
     inputs:
       artifactName: libvnc
-  - script: |
-      mkdir $(Build.ArtifactStagingDirectory)/opencover
-      mkdir $(Build.ArtifactStagingDirectory)/codecoverage
-      mkdir $(Build.ArtifactStagingDirectory)/testResultsFiles
-
-      cd RemoteViewing.Tests
-      dotnet test RemoteViewing.Tests.csproj -l "trx;LogFileName=$(Build.ArtifactStagingDirectory)/testResultsFiles/RemoteViewing.Tests.trx" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput="$(Build.ArtifactStagingDirectory)/opencover/RemoteViewing.Tests.opencover.xml"
-
-      dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools
-      tools\reportgenerator.exe "-reports:$(Build.ArtifactStagingDirectory)/opencover/*.opencover.xml" "-targetdir:$(Build.ArtifactStagingDirectory)/codecoverage" -reporttypes:Cobertura
-    displayName: 'Test'
+    # Apparently code coverage isn't really supposed to work, but it should work soon. Sigh.
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/11677
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/9954
+  - task: DotNetCoreCLI@2
+    inputs:
+      command: test
+      projects: '**/*Tests/*.csproj'
+      arguments: ' --collect "Code coverage"'
   - script: |
       mkdir $(Build.ArtifactStagingDirectory)/nuget
       dotnet pack -c Release -o $(Build.ArtifactStagingDirectory)/nuget
     displayName: 'Package'
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: 'cobertura'
-      summaryFileLocation: $(Build.ArtifactStagingDirectory)/codecoverage/Cobertura.xml
-      reportDirectory: $(Build.ArtifactStagingDirectory)/codecoverage
-      failIfCoverageEmpty: true
-    condition: true
-  - task: PublishTestResults@2
-    inputs:
-      testRunner: VSTest
-      testResultsFiles: $(Build.ArtifactStagingDirectory)/testResultsFiles/*.trx
-    condition: true
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'

--- a/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
+++ b/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Quamotion.RemoteViewing.LibVnc.NativeBinaries" Version="*" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/RemoteViewing.Tests/RemoteViewing.Tests.csproj
+++ b/RemoteViewing.Tests/RemoteViewing.Tests.csproj
@@ -11,11 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.8.0" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Apparently code coverage isn't really supposed to work, but it should work soon. Sigh.

https://github.com/microsoft/azure-pipelines-tasks/issues/11677
https://github.com/microsoft/azure-pipelines-tasks/issues/9954