### PR TITLE
Add support for copies of libvncserver compiled with native Win32 threading support

### DIFF
--- a/RemoteViewing.LibVnc.Tests/RfbClientRecPtrTests.cs
+++ b/RemoteViewing.LibVnc.Tests/RfbClientRecPtrTests.cs
@@ -45,9 +45,15 @@ namespace RemoteViewing.LibVnc.Tests
         /// Tests the <see cref="RfbClientRefPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit Windows.
         /// </summary>
         [Fact]
-        public void GetFieldOffsetsTest_Win64()
+        public void GetFieldOffsetsTest_Win64_Pthread()
         {
-            var offsets = RfbClientRecPtr.GetFieldOffsets(OSPlatform.Windows, is64Bit: true);
+            var offsets = RfbClientRecPtr.GetFieldOffsets(
+                OSPlatform.Windows,
+                is64Bit: true,
+                new NativeCapabilities()
+                {
+                    HaveLibPthread = true,
+                });
 
             Assert.Equal(0, offsets[(int)RfbClientRecPtrField.Screen]);
             Assert.Equal(8, offsets[(int)RfbClientRecPtrField.ScaledScreen]);
@@ -132,6 +138,104 @@ namespace RemoteViewing.LibVnc.Tests
             Assert.Equal(30488, offsets[(int)RfbClientRecPtrField.UseExtDesktopSize]);
             Assert.Equal(30492, offsets[(int)RfbClientRecPtrField.RequestedDesktopSizeChange]);
             Assert.Equal(30496, offsets[(int)RfbClientRecPtrField.LastDesktopSizeChangeError]);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="RfbClientRefPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit Windows.
+        /// </summary>
+        [Fact]
+        public void GetFieldOffsetsTest_Win64()
+        {
+            var offsets = RfbClientRecPtr.GetFieldOffsets(
+                OSPlatform.Windows,
+                is64Bit: true,
+                new NativeCapabilities()
+                {
+                    HaveWin32Threads = true,
+                });
+
+            Assert.Equal(0, offsets[(int)RfbClientRecPtrField.Screen]);
+            Assert.Equal(8, offsets[(int)RfbClientRecPtrField.ScaledScreen]);
+            Assert.Equal(16, offsets[(int)RfbClientRecPtrField.PalmVNC]);
+            Assert.Equal(24, offsets[(int)RfbClientRecPtrField.ClientData]);
+            Assert.Equal(32, offsets[(int)RfbClientRecPtrField.ClientGoneHook]);
+            Assert.Equal(40, offsets[(int)RfbClientRecPtrField.Sock]);
+            Assert.Equal(48, offsets[(int)RfbClientRecPtrField.Host]);
+            Assert.Equal(56, offsets[(int)RfbClientRecPtrField.ProtocolMajorVersion]);
+            Assert.Equal(60, offsets[(int)RfbClientRecPtrField.ProtocolMinorVersion]);
+            Assert.Equal(64, offsets[(int)RfbClientRecPtrField.Client_thread]);
+            Assert.Equal(72, offsets[(int)RfbClientRecPtrField.State]);
+            Assert.Equal(76, offsets[(int)RfbClientRecPtrField.ReverseConnection]);
+            Assert.Equal(77, offsets[(int)RfbClientRecPtrField.OnHold]);
+            Assert.Equal(78, offsets[(int)RfbClientRecPtrField.ReadyForSetColourMapEntries]);
+            Assert.Equal(79, offsets[(int)RfbClientRecPtrField.UseCopyRect]);
+            Assert.Equal(80, offsets[(int)RfbClientRecPtrField.PreferredEncoding]);
+            Assert.Equal(84, offsets[(int)RfbClientRecPtrField.CorreMaxWidth]);
+            Assert.Equal(88, offsets[(int)RfbClientRecPtrField.CorreMaxHeight]);
+            Assert.Equal(92, offsets[(int)RfbClientRecPtrField.ViewOnly]);
+            Assert.Equal(93, offsets[(int)RfbClientRecPtrField.AuthChallenge]);
+            Assert.Equal(112, offsets[(int)RfbClientRecPtrField.CopyRegion]);
+            Assert.Equal(120, offsets[(int)RfbClientRecPtrField.CopyDX]);
+            Assert.Equal(124, offsets[(int)RfbClientRecPtrField.CopyDY]);
+            Assert.Equal(128, offsets[(int)RfbClientRecPtrField.ModifiedRegion]);
+            Assert.Equal(136, offsets[(int)RfbClientRecPtrField.RequestedRegion]);
+            Assert.Equal(144, offsets[(int)RfbClientRecPtrField.StartDeferring]);
+            Assert.Equal(152, offsets[(int)RfbClientRecPtrField.StartPtrDeferring]);
+            Assert.Equal(160, offsets[(int)RfbClientRecPtrField.LastPtrX]);
+            Assert.Equal(164, offsets[(int)RfbClientRecPtrField.LastPtrY]);
+            Assert.Equal(168, offsets[(int)RfbClientRecPtrField.LastPtrButtons]);
+            Assert.Equal(176, offsets[(int)RfbClientRecPtrField.TranslateFn]);
+            Assert.Equal(184, offsets[(int)RfbClientRecPtrField.TranslateLookupTable]);
+            Assert.Equal(192, offsets[(int)RfbClientRecPtrField.Format]);
+            Assert.Equal(208, offsets[(int)RfbClientRecPtrField.UpdateBuf]);
+            Assert.Equal(30208, offsets[(int)RfbClientRecPtrField.Ublen]);
+            Assert.Equal(30216, offsets[(int)RfbClientRecPtrField.StatEncList]);
+            Assert.Equal(30224, offsets[(int)RfbClientRecPtrField.StatMsgList]);
+            Assert.Equal(30232, offsets[(int)RfbClientRecPtrField.RawBytesEquivalent]);
+            Assert.Equal(30236, offsets[(int)RfbClientRecPtrField.BytesSent]);
+            Assert.Equal(30240, offsets[(int)RfbClientRecPtrField.CompStreamInitedLZO]);
+            Assert.Equal(30248, offsets[(int)RfbClientRecPtrField.LzoWrkMem]);
+            Assert.Equal(30256, offsets[(int)RfbClientRecPtrField.FileTransfer]);
+            Assert.Equal(30280, offsets[(int)RfbClientRecPtrField.LastKeyboardLedState]);
+            Assert.Equal(30284, offsets[(int)RfbClientRecPtrField.EnableSupportedMessages]);
+            Assert.Equal(30285, offsets[(int)RfbClientRecPtrField.EnableSupportedEncodings]);
+            Assert.Equal(30286, offsets[(int)RfbClientRecPtrField.EnableServerIdentity]);
+            Assert.Equal(30287, offsets[(int)RfbClientRecPtrField.EnableKeyboardLedState]);
+            Assert.Equal(30288, offsets[(int)RfbClientRecPtrField.EnableLastRectEncoding]);
+            Assert.Equal(30289, offsets[(int)RfbClientRecPtrField.EnableCursorShapeUpdates]);
+            Assert.Equal(30290, offsets[(int)RfbClientRecPtrField.EnableCursorPosUpdates]);
+            Assert.Equal(30291, offsets[(int)RfbClientRecPtrField.UseRichCursorEncoding]);
+            Assert.Equal(30292, offsets[(int)RfbClientRecPtrField.CursorWasChanged]);
+            Assert.Equal(30293, offsets[(int)RfbClientRecPtrField.CursorWasMoved]);
+            Assert.Equal(30296, offsets[(int)RfbClientRecPtrField.CursorX]);
+            Assert.Equal(30300, offsets[(int)RfbClientRecPtrField.CursorY]);
+            Assert.Equal(30304, offsets[(int)RfbClientRecPtrField.UseNewFBSize]);
+            Assert.Equal(30305, offsets[(int)RfbClientRecPtrField.NewFBSizePending]);
+            Assert.Equal(30312, offsets[(int)RfbClientRecPtrField.Prev]);
+            Assert.Equal(30320, offsets[(int)RfbClientRecPtrField.Next]);
+            Assert.Equal(30328, offsets[(int)RfbClientRecPtrField.RefCount]);
+            Assert.Equal(30336, offsets[(int)RfbClientRecPtrField.RefCountMutex]);
+            Assert.Equal(30376, offsets[(int)RfbClientRecPtrField.DeleteCond]);
+            Assert.Equal(30384, offsets[(int)RfbClientRecPtrField.OutputMutex]);
+            Assert.Equal(30424, offsets[(int)RfbClientRecPtrField.UpdateMutex]);
+            Assert.Equal(30464, offsets[(int)RfbClientRecPtrField.UpdateCond]);
+            Assert.Equal(30472, offsets[(int)RfbClientRecPtrField.ProgressiveSliceY]);
+            Assert.Equal(30480, offsets[(int)RfbClientRecPtrField.Extensions]);
+            Assert.Equal(30488, offsets[(int)RfbClientRecPtrField.ZrleBeforeBuf]);
+            Assert.Equal(30496, offsets[(int)RfbClientRecPtrField.PaletteHelper]);
+            Assert.Equal(30504, offsets[(int)RfbClientRecPtrField.SendMutex]);
+            Assert.Equal(30544, offsets[(int)RfbClientRecPtrField.BeforeEncBuf]);
+            Assert.Equal(30552, offsets[(int)RfbClientRecPtrField.BeforeEncBufSize]);
+            Assert.Equal(30560, offsets[(int)RfbClientRecPtrField.AfterEncBuf]);
+            Assert.Equal(30568, offsets[(int)RfbClientRecPtrField.AfterEncBufSize]);
+            Assert.Equal(30572, offsets[(int)RfbClientRecPtrField.AfterEncBufLen]);
+            Assert.Equal(30576, offsets[(int)RfbClientRecPtrField.Sslctx]);
+            Assert.Equal(30584, offsets[(int)RfbClientRecPtrField.Wsctx]);
+            Assert.Equal(30592, offsets[(int)RfbClientRecPtrField.Wspath]);
+            Assert.Equal(30600, offsets[(int)RfbClientRecPtrField.ClientFramebufferUpdateRequestHook]);
+            Assert.Equal(30608, offsets[(int)RfbClientRecPtrField.UseExtDesktopSize]);
+            Assert.Equal(30612, offsets[(int)RfbClientRecPtrField.RequestedDesktopSizeChange]);
+            Assert.Equal(30616, offsets[(int)RfbClientRecPtrField.LastDesktopSizeChangeError]);
         }
 
         /// <summary>

--- a/RemoteViewing.LibVnc.Tests/RfbScreenInfoPtrTests.cs
+++ b/RemoteViewing.LibVnc.Tests/RfbScreenInfoPtrTests.cs
@@ -38,6 +38,10 @@ namespace RemoteViewing.LibVnc.Tests
     /// </summary>
     public unsafe class RfbScreenInfoPtrTests
     {
+        // You can use the following regex to transform output of get_offset.c to xUnit assert statements:
+        //   offsetof\(rfbScreenInfo, ([a-zA-Z_]*)\) : (\d*)
+        //   Assert.Equal($2, offsets[(int)RfbScreenInfoPtrField.$1]);
+
         /// <summary>
         /// Tests the basic layout of the <see cref="RfbScreenInfoPtr"/> class by accessing most properties.
         /// </summary>
@@ -102,9 +106,15 @@ namespace RemoteViewing.LibVnc.Tests
         /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 64-bit Windows.
         /// </summary>
         [Fact]
-        public void GetFieldOffsetsTest_Win64()
+        public void GetFieldOffsetsTest_Win64_Pthread()
         {
-            var offsets = RfbScreenInfoPtr.GetFieldOffsets(OSPlatform.Windows, is64Bit: true);
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(
+                OSPlatform.Windows,
+                is64Bit: true,
+                new NativeCapabilities()
+                {
+                     HaveLibPthread = true,
+                });
 
             Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
             Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
@@ -197,6 +207,108 @@ namespace RemoteViewing.LibVnc.Tests
             Assert.Equal(1344, offsets[(int)RfbScreenInfoPtrField.FdQuota]);
         }
 
+        [Fact]
+        public void GetFieldOffsetstest_Win64()
+        {
+            var offsets = RfbScreenInfoPtr.GetFieldOffsets(
+                OSPlatform.Windows,
+                is64Bit: true,
+                new NativeCapabilities()
+                {
+                    HaveLibPthread = false,
+                    HaveWin32Threads = true,
+                });
+
+            Assert.Equal(0, offsets[(int)RfbScreenInfoPtrField.ScaledScreenNext]);
+            Assert.Equal(8, offsets[(int)RfbScreenInfoPtrField.ScaledScreenRefCount]);
+            Assert.Equal(12, offsets[(int)RfbScreenInfoPtrField.Width]);
+            Assert.Equal(16, offsets[(int)RfbScreenInfoPtrField.PaddedWidthInBytes]);
+            Assert.Equal(20, offsets[(int)RfbScreenInfoPtrField.Height]);
+            Assert.Equal(24, offsets[(int)RfbScreenInfoPtrField.Depth]);
+            Assert.Equal(28, offsets[(int)RfbScreenInfoPtrField.BitsPerPixel]);
+            Assert.Equal(32, offsets[(int)RfbScreenInfoPtrField.SizeInBytes]);
+            Assert.Equal(36, offsets[(int)RfbScreenInfoPtrField.BlackPixel]);
+            Assert.Equal(40, offsets[(int)RfbScreenInfoPtrField.WhitePixel]);
+            Assert.Equal(48, offsets[(int)RfbScreenInfoPtrField.ScreenData]);
+            Assert.Equal(56, offsets[(int)RfbScreenInfoPtrField.ServerFormat]);
+            Assert.Equal(72, offsets[(int)RfbScreenInfoPtrField.ColourMap]);
+            Assert.Equal(88, offsets[(int)RfbScreenInfoPtrField.DesktopName]);
+            Assert.Equal(96, offsets[(int)RfbScreenInfoPtrField.ThisHost]);
+            Assert.Equal(351, offsets[(int)RfbScreenInfoPtrField.AutoPort]);
+            Assert.Equal(352, offsets[(int)RfbScreenInfoPtrField.Port]);
+            Assert.Equal(360, offsets[(int)RfbScreenInfoPtrField.ListenSock]);
+            Assert.Equal(368, offsets[(int)RfbScreenInfoPtrField.MaxSock]);
+            Assert.Equal(372, offsets[(int)RfbScreenInfoPtrField.MaxFd]);
+            Assert.Equal(376, offsets[(int)RfbScreenInfoPtrField.AllFds]);
+            Assert.Equal(896, offsets[(int)RfbScreenInfoPtrField.SocketState]);
+            Assert.Equal(904, offsets[(int)RfbScreenInfoPtrField.InetdSock]);
+            Assert.Equal(912, offsets[(int)RfbScreenInfoPtrField.InetdInitDone]);
+            Assert.Equal(916, offsets[(int)RfbScreenInfoPtrField.UdpPort]);
+            Assert.Equal(920, offsets[(int)RfbScreenInfoPtrField.UdpSock]);
+            Assert.Equal(928, offsets[(int)RfbScreenInfoPtrField.UdpClient]);
+            Assert.Equal(936, offsets[(int)RfbScreenInfoPtrField.UdpSockConnected]);
+            Assert.Equal(940, offsets[(int)RfbScreenInfoPtrField.UdpRemoteAddr]);
+            Assert.Equal(956, offsets[(int)RfbScreenInfoPtrField.MaxClientWait]);
+            Assert.Equal(960, offsets[(int)RfbScreenInfoPtrField.HttpInitDone]);
+            Assert.Equal(961, offsets[(int)RfbScreenInfoPtrField.HttpEnableProxyConnect]);
+            Assert.Equal(964, offsets[(int)RfbScreenInfoPtrField.HttpPort]);
+            Assert.Equal(968, offsets[(int)RfbScreenInfoPtrField.HttpDir]);
+            Assert.Equal(976, offsets[(int)RfbScreenInfoPtrField.HttpListenSock]);
+            Assert.Equal(984, offsets[(int)RfbScreenInfoPtrField.HttpSock]);
+            Assert.Equal(992, offsets[(int)RfbScreenInfoPtrField.PasswordCheck]);
+            Assert.Equal(1000, offsets[(int)RfbScreenInfoPtrField.AuthPasswdData]);
+            Assert.Equal(1008, offsets[(int)RfbScreenInfoPtrField.AuthPasswdFirstViewOnly]);
+            Assert.Equal(1016, offsets[(int)RfbScreenInfoPtrField.DeferUpdateTime]);
+            Assert.Equal(1020, offsets[(int)RfbScreenInfoPtrField.AlwaysShared]);
+            Assert.Equal(1021, offsets[(int)RfbScreenInfoPtrField.NeverShared]);
+            Assert.Equal(1022, offsets[(int)RfbScreenInfoPtrField.DontDisconnect]);
+            Assert.Equal(1024, offsets[(int)RfbScreenInfoPtrField.ClientHead]);
+            Assert.Equal(1032, offsets[(int)RfbScreenInfoPtrField.PointerClient]);
+            Assert.Equal(1040, offsets[(int)RfbScreenInfoPtrField.CursorX]);
+            Assert.Equal(1044, offsets[(int)RfbScreenInfoPtrField.CursorY]);
+            Assert.Equal(1048, offsets[(int)RfbScreenInfoPtrField.UnderCursorBufferLen]);
+            Assert.Equal(1056, offsets[(int)RfbScreenInfoPtrField.UnderCursorBuffer]);
+            Assert.Equal(1064, offsets[(int)RfbScreenInfoPtrField.DontConvertRichCursorToXCursor]);
+            Assert.Equal(1072, offsets[(int)RfbScreenInfoPtrField.Cursor]);
+            Assert.Equal(1080, offsets[(int)RfbScreenInfoPtrField.FrameBuffer]);
+            Assert.Equal(1088, offsets[(int)RfbScreenInfoPtrField.KbdAddEvent]);
+            Assert.Equal(1096, offsets[(int)RfbScreenInfoPtrField.KbdReleaseAllKeys]);
+            Assert.Equal(1104, offsets[(int)RfbScreenInfoPtrField.PtrAddEvent]);
+            Assert.Equal(1112, offsets[(int)RfbScreenInfoPtrField.SetXCutText]);
+            Assert.Equal(1120, offsets[(int)RfbScreenInfoPtrField.GetCursorPtr]);
+            Assert.Equal(1128, offsets[(int)RfbScreenInfoPtrField.SetTranslateFunction]);
+            Assert.Equal(1136, offsets[(int)RfbScreenInfoPtrField.SetSingleWindow]);
+            Assert.Equal(1144, offsets[(int)RfbScreenInfoPtrField.SetServerInput]);
+            Assert.Equal(1152, offsets[(int)RfbScreenInfoPtrField.GetFileTransferPermission]);
+            Assert.Equal(1160, offsets[(int)RfbScreenInfoPtrField.SetTextChat]);
+            Assert.Equal(1168, offsets[(int)RfbScreenInfoPtrField.NewClientHook]);
+            Assert.Equal(1176, offsets[(int)RfbScreenInfoPtrField.DisplayHook]);
+            Assert.Equal(1184, offsets[(int)RfbScreenInfoPtrField.GetKeyboardLedStateHook]);
+            Assert.Equal(1192, offsets[(int)RfbScreenInfoPtrField.CursorMutex]);
+            Assert.Equal(1232, offsets[(int)RfbScreenInfoPtrField.BackgroundLoop]);
+            Assert.Equal(1233, offsets[(int)RfbScreenInfoPtrField.IgnoreSIGPIPE]);
+            Assert.Equal(1236, offsets[(int)RfbScreenInfoPtrField.ProgressiveSliceHeight]);
+            Assert.Equal(1240, offsets[(int)RfbScreenInfoPtrField.ListenInterface]);
+            Assert.Equal(1244, offsets[(int)RfbScreenInfoPtrField.DeferPtrUpdateTime]);
+            Assert.Equal(1248, offsets[(int)RfbScreenInfoPtrField.HandleEventsEagerly]);
+            Assert.Equal(1256, offsets[(int)RfbScreenInfoPtrField.VersionString]);
+            Assert.Equal(1264, offsets[(int)RfbScreenInfoPtrField.ProtocolMajorVersion]);
+            Assert.Equal(1268, offsets[(int)RfbScreenInfoPtrField.ProtocolMinorVersion]);
+            Assert.Equal(1272, offsets[(int)RfbScreenInfoPtrField.PermitFileTransfer]);
+            Assert.Equal(1280, offsets[(int)RfbScreenInfoPtrField.DisplayFinishedHook]);
+            Assert.Equal(1288, offsets[(int)RfbScreenInfoPtrField.XvpHooka]);
+            Assert.Equal(1296, offsets[(int)RfbScreenInfoPtrField.Sslkeyfile]);
+            Assert.Equal(1304, offsets[(int)RfbScreenInfoPtrField.Sslcertfile]);
+            Assert.Equal(1312, offsets[(int)RfbScreenInfoPtrField.Ipv6port]);
+            Assert.Equal(1320, offsets[(int)RfbScreenInfoPtrField.Listen6Interface]);
+            Assert.Equal(1328, offsets[(int)RfbScreenInfoPtrField.Listen6Sock]);
+            Assert.Equal(1336, offsets[(int)RfbScreenInfoPtrField.Http6Port]);
+            Assert.Equal(1344, offsets[(int)RfbScreenInfoPtrField.HttpListen6Sock]);
+            Assert.Equal(1352, offsets[(int)RfbScreenInfoPtrField.SetDesktopSizeHook]);
+            Assert.Equal(1360, offsets[(int)RfbScreenInfoPtrField.NumberOfExtDesktopScreensHook]);
+            Assert.Equal(1368, offsets[(int)RfbScreenInfoPtrField.GetExtDesktopScreenHook]);
+            Assert.Equal(1376, offsets[(int)RfbScreenInfoPtrField.FdQuota]);
+        }
         /// <summary>
         /// Tests the <see cref="RfbScreenInfoPtr.GetFieldOffsets(OSPlatform, bool)"/> method for 32-bit Windows.
         /// </summary>

--- a/RemoteViewing.LibVnc/Interop/NativeCapabilities.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeCapabilities.cs
@@ -1,0 +1,72 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// Defines the capabilities with which a build of libvncserver has been compiled.
+    /// </summary>
+    public struct NativeCapabilities
+    {
+        /// <summary>
+        /// The default Unix (Linux and macOS) capabilities.
+        /// </summary>
+        public static NativeCapabilities Unix = new NativeCapabilities()
+        {
+            HaveLibZ = true,
+            HaveLibPng = true,
+            HaveLibJpeg = true,
+            HaveLibPthread = true,
+        };
+
+        /// <summary>
+        /// libvncserver has been compiled with libz support.
+        /// </summary>
+        public bool HaveLibZ;
+
+        /// <summary>
+        /// libvncserver has been compiled with libpng support.
+        /// </summary>
+        public bool HaveLibPng;
+
+        /// <summary>
+        /// libvncserver has been compiled with libjpeg support.
+        /// </summary>
+        public bool HaveLibJpeg;
+
+        /// <summary>
+        /// libvncserver has been compiled with WIN32 threading support.
+        /// </summary>
+        public bool HaveWin32Threads;
+
+        /// <summary>
+        /// libvncserver has been compile with libpthread support.
+        /// </summary>
+        public bool HaveLibPthread;
+    }
+}

--- a/RemoteViewing.LibVnc/Interop/NativeLayout.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLayout.cs
@@ -73,6 +73,7 @@ namespace RemoteViewing.LibVnc.Interop
                     8, // Int_2,
                     16, // Byte_CHALLENGESIZE,
                     8, // PthreadT,
+                    40, // Win32Mutex
                 },
 
                 // alignments
@@ -106,6 +107,7 @@ namespace RemoteViewing.LibVnc.Interop
                     1, // Int_2,
                     1, // Byte_CHALLENGESIZE,
                     1, // PthreadT,
+                    8, // Win32Mutex
                 },
             };
 
@@ -146,6 +148,7 @@ namespace RemoteViewing.LibVnc.Interop
                     8, // Int_2,
                     16, // Byte_CHALLENGESIZE,
                     4, // PthreadT,
+                    40, // Win32Mutex
                 },
 
                 // alignments
@@ -179,6 +182,7 @@ namespace RemoteViewing.LibVnc.Interop
                     1, // Int_2,
                     1, // Byte_CHALLENGESIZE,
                     1, // PthreadT,
+                    4, // Win32Mutex
                 },
             };
 
@@ -219,6 +223,7 @@ namespace RemoteViewing.LibVnc.Interop
                     8, // Int_2,
                     16, // Byte_CHALLENGESIZE,
                     8, // PthreadT,
+                    0, // Win32Mutex
                 },
 
                 // alignments
@@ -252,6 +257,7 @@ namespace RemoteViewing.LibVnc.Interop
                     1, // Int_2,
                     1, // Byte_CHALLENGESIZE,
                     1, // PthreadT,
+                    1, // Win32Mutex
                 },
             };
 
@@ -292,6 +298,7 @@ namespace RemoteViewing.LibVnc.Interop
                     8, // Int_2,
                     16, // Byte_CHALLENGESIZE,
                     8, // PthreadT,
+                    0, // Win32Mutex
                 },
 
                 // alignments
@@ -325,6 +332,7 @@ namespace RemoteViewing.LibVnc.Interop
                     1, // Int_2,
                     1, // Byte_CHALLENGESIZE,
                     1, // PthreadT,
+                    1, // Win32Mutex
                 },
             };
 

--- a/RemoteViewing.LibVnc/Interop/RfbType.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbType.cs
@@ -94,9 +94,9 @@ namespace RemoteViewing.LibVnc.Interop
         SockAddrIn,
 
         /// <summary>
-        /// The field is of type <c>MUTEX()</c>.
+        /// The field is of type <c>MUTEX()</c> when using Pthread.
         /// </summary>
-        Mutex,
+        PthreadMutex,
 
         /// <summary>
         /// The field is of type <c>in_addr_t</c>.
@@ -167,5 +167,10 @@ namespace RemoteViewing.LibVnc.Interop
         /// The field is of type <c>pthread_t</c>.
         /// </summary>
         PthreadT,
+
+        /// <summary>
+        /// The field is of type <c>MUTEX()</c> when using Win32 threading.
+        /// </summary>
+        Win32Mutex,
     }
 }

--- a/RemoteViewing.LibVnc/get_offsets.c
+++ b/RemoteViewing.LibVnc/get_offsets.c
@@ -36,6 +36,10 @@ int main()
 	printf("sizeof(pthread_mutex_t): %zu\n", sizeof(pthread_mutex_t));
 #endif
 
+#ifdef LIBVNCSERVER_HAVE_WIN32THREADS
+   printf("sizeof(CRITICAL_SECTION): %zu\n", sizeof(CRITICAL_SECTION));
+#endif
+
 #ifdef LIBVNCSERVER_HAVE_LIBJPEG
 	printf("sizeof(z_stream): %zu\n", sizeof(z_stream));
 #endif


### PR DESCRIPTION
The struct layouts are different when using Win32 threading (as opposed to libpthread on Windows). Account for this.