### PR TITLE
ServerExample: UseVncServer, allow resizing of the framebuffer source

### DIFF
--- a/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
+++ b/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
@@ -9,7 +9,7 @@ namespace RemoteViewing.NoVncExample
     /// A dummy framebuffer source, which shows a rectangle with changing colors. Used to verify the noVNC middleware is
     /// working correctly.
     /// </summary>
-    public class DummyFramebufferSource : IVncFramebufferSource
+    public class DummyFramebufferSource : IVncFramebufferSource, IVncRemoteKeyboard, IVncRemoteController
     {
         private readonly Random random = new Random();
 
@@ -17,11 +17,6 @@ namespace RemoteViewing.NoVncExample
         private sbyte[] increments = new sbyte[3] { 5, 5, 5 };
 
         private VncFramebuffer framebuffer;
-
-        // The width and height of the framebuffer source.
-        // These values can be changed by the client
-        private int width = 400;
-        private int height = 400;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DummyFramebufferSource"/> class.
@@ -33,6 +28,30 @@ namespace RemoteViewing.NoVncExample
         /// <inheritdoc/>
         public bool SupportsResizing => true;
 
+        // The width and height of the framebuffer source.
+        // These values can be changed by the client
+
+        /// <summary>
+        /// Gets or sets the width of the framebuffer.
+        /// </summary>
+        public int Width
+        { get; set; } = 200;
+
+        /// <summary>
+        /// Gets or sets the height of the framebuffer.
+        /// </summary>
+        public int Height
+        { get; set; } = 400;
+
+        /// <summary>
+        /// Gets or sets a string to add to the test message displayed on the screen.
+        /// </summary>
+        public string TextSuffix
+        {
+            get;
+            set;
+        }
+
         /// <inheritdoc/>
         public ExtendedDesktopSizeStatus SetDesktopSize(int width, int height)
         {
@@ -41,8 +60,8 @@ namespace RemoteViewing.NoVncExample
                 return ExtendedDesktopSizeStatus.Prohibited;
             }
 
-            this.width = width;
-            this.height = height;
+            this.Width = width;
+            this.Height = height;
             return ExtendedDesktopSizeStatus.Success;
         }
 
@@ -61,14 +80,14 @@ namespace RemoteViewing.NoVncExample
 
             var color = Color.FromArgb(this.colors[0], this.colors[1], this.colors[2]);
 
-            using (Bitmap image = new Bitmap(this.width, this.height))
+            using (Bitmap image = new Bitmap(this.Width, this.Height))
             using (Graphics gfx = Graphics.FromImage(image))
             using (SolidBrush brush = new SolidBrush(color))
             using (var font = new Font(FontFamily.GenericSansSerif, 12.0f, FontStyle.Bold, GraphicsUnit.Pixel))
             {
                 gfx.FillRectangle(brush, 0, 0, image.Width, image.Height);
 
-                var text = $"RemoteViewing {ThisAssembly.AssemblyInformationalVersion}";
+                var text = $"RemoteViewing {ThisAssembly.AssemblyInformationalVersion}. {this.TextSuffix}";
                 var size = gfx.MeasureString(text, font);
 
                 var position = new PointF((image.Width - size.Width) / 2.0f, (image.Height - size.Height) / 2.0f);
@@ -97,6 +116,35 @@ namespace RemoteViewing.NoVncExample
                 }
 
                 return this.framebuffer;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void HandleTouchEvent(object sender, PointerChangedEventArgs e)
+        {
+            this.TextSuffix = $"Mouse at ({e.X},{e.Y})";
+        }
+
+        /// <inheritdoc/>
+        public void HandleKeyEvent(object sender, KeyChangedEventArgs e)
+        {
+            if (e.Keysym == KeySym.Plus && e.Pressed == false)
+            {
+                this.Width *= 2;
+                this.Height *= 2;
+            }
+
+            if (e.Keysym == KeySym.Minus && e.Pressed == false)
+            {
+                this.Width /= 2;
+                this.Height /= 2;
+            }
+
+            if (e.Keysym == KeySym.r && e.Pressed == false)
+            {
+                var temp = this.Width;
+                this.Width = this.Height;
+                this.Height = temp;
             }
         }
     }


### PR DESCRIPTION
This PR rewrites the VNC Server example:

- The example now uses the `VncServer` class to start the VNC server.
- The demo framebuffer source now acts as a keyboard and mouse controller; the keyboard responds to:
  * the `r` key which rotates the screen
  * the `+` key which doubles the framebuffer size
  * the `-` key which cuts the framebuffer size in half
- The demo framebuffer source now acts as a controller; moving the mouse will now result in the position of the cursor being displayed in the framebuffer.