### PR TITLE
Add (lib)vnclogger.[so|dylib|dll]

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -33,6 +33,14 @@ jobs:
       gcc -o $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets -I . -I ../libvncserver/ -I ../libvncserver/common/ $(Build.SourcesDirectory)/RemoteViewing.LibVnc/get_offsets.c
       $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets > $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets.txt
     workingDirectory: build
+  - script : |
+      mkdir build
+      cd build
+      cmake ..
+      make
+      cp *.dylib $(Build.ArtifactStagingDirectory)/$(rid)/lib/
+    workingDirectory: '$(Build.SourcesDirectory)/RemoteViewing.LibVnc.Logging'
+    displayName: Build vnclogger
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
@@ -84,10 +92,17 @@ jobs:
     displayName: Compile LibVNC
   - script: |
       mkdir $(Build.ArtifactStagingDirectory)\$(rid)\
-      echo copy Release\*.* $(Build.ArtifactStagingDirectory)\$(rid)\
       copy Release\*.* $(Build.ArtifactStagingDirectory)\$(rid)\
     workingDirectory: build
     displayName: Install LibVNC
+  - script : |
+      mkdir build
+      cd build
+      cmake ..
+      cmake --build . --config Release
+      copy Release\*.* $(Build.ArtifactStagingDirectory)\$(rid)\
+    workingDirectory: '$(Build.SourcesDirectory)/RemoteViewing.LibVnc.Logging'
+    displayName: Build vnclogger
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)/'
@@ -108,11 +123,19 @@ jobs:
       sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
     displayName: Set up sudo
   - script: |
-      sudo apt-get install -y libvncserver-dev gcc
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libvncserver-dev gcc clang cmake
       
       mkdir -p $(Build.ArtifactStagingDirectory)/$(rid)
       gcc -o $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets -I . -I .. $(Build.SourcesDirectory)/RemoteViewing.LibVnc/get_offsets.c
       $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets > $(Build.ArtifactStagingDirectory)/$(rid)/get_offsets.txt
+  - script : |
+      mkdir build
+      cd build
+      cmake ..
+      make
+      cp *.so $(Build.ArtifactStagingDirectory)/$(rid)/
+    workingDirectory: '$(Build.SourcesDirectory)/RemoteViewing.LibVnc.Logging'
+    displayName: Build vnclogger
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/RemoteViewing.LibVnc.Logging/CMakeLists.txt
+++ b/RemoteViewing.LibVnc.Logging/CMakeLists.txt
@@ -1,0 +1,32 @@
+﻿# RemoteViewing VNC Client/Server Library for .NET
+# Copyright (c) 2020 Quamotion bvba
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+cmake_minimum_required (VERSION 3.8)
+
+project ("vnclogger")
+
+add_library (
+	vnclogger
+	SHARED
+	"vnclogger.c")

--- a/RemoteViewing.LibVnc.Logging/vnclogger.c
+++ b/RemoteViewing.LibVnc.Logging/vnclogger.c
@@ -1,0 +1,87 @@
+﻿// RemoteViewing VNC Client/Server Library for .NET
+// Copyright (c) 2020 Quamotion bvba
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// libvncserver defines the logging functions like this:
+// typedef void (*rfbLogProc)(const char *format, ...);
+//
+// .NET has the __arglist keyword which is equivalent to ...,
+// but this does not work in callbacks, see
+// https://github.com/dotnet/runtime/issues/9316#issuecomment-353790995
+//
+// As a workaround, this library defines a function which takes care
+// of message formatting in C and then invokes a delegate (which can
+// be in managed code) with the formatted message.
+
+#if defined (WIN32)
+#define _CRT_SECURE_NO_WARNINGS
+#define DllExport   __declspec( dllexport )
+#else
+#define DllExport
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+typedef void (*LogProc)(int level, char* message, int length);
+
+DllExport LogProc logCallback = NULL;
+
+static void Log(int level, const char* format, va_list args)
+{
+    int length = vsnprintf(NULL, 0, format, args) + 1;
+
+    char* buffer = (char*)malloc(length * sizeof(char));
+
+    if (buffer != NULL)
+    {
+        vsprintf(buffer, format, args);
+
+        logCallback(level, buffer, length);
+
+        free(buffer);
+    }
+}
+
+DllExport void
+LogMessage(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    Log(0, format, args);
+    
+    va_end(args);
+}
+
+DllExport void
+LogError(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    Log(1, format, args);
+    
+    va_end(args);
+}

--- a/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
+++ b/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
@@ -26,7 +26,7 @@
       <Pack>true</Pack>
     </Content>
 
-    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/osx-x64/lib/libvncclient.dylib">
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/osx-x64/lib/libvnclogger.dylib">
       <PackagePath>runtimes/osx-64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
@@ -38,6 +38,11 @@
 
     <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/win7-x86/*.dll">
       <PackagePath>runtimes/win7-x86/native/%(Filename)%(Extension)</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+
+    <Content Include="$(SYSTEM_ARTIFACTSDIRECTORY)/libvnc/linux-x64/libvnclogger.so">
+      <PackagePath>runtimes/linux-x64/native/%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
This library acts as a bridge between the C declaration of the logging callback (which uses the `...` - varargs syntax) and .NET, which cannot interop with this.