### PR TITLE
Use the vnclogger interop library

### DIFF
--- a/RemoteViewing.LibVnc/Interop/NativeLogging.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLogging.cs
@@ -1,0 +1,160 @@
+﻿#region License
+/*
+RemoteViewing VNC Client/Server Library for .NET
+Copyright (c) 2020 Quamotion bvba
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#endregion
+
+#if !NETSTANDARD2_0
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace RemoteViewing.LibVnc.Interop
+{
+    /// <summary>
+    /// This class contains the logic required to set a delegate which is called by libvncserver when logging.
+    /// libvncserver logging uses a callback with a variable number of arguments, which is not supported by
+    /// P/Invoke in .NET Core, we need to pass through a tiny layer of native code which handles the conversion.
+    /// </summary>
+    public class NativeLogging
+    {
+        /// <summary>
+        /// The name of the libvncserver library.
+        /// </summary>
+        public const string ServerLibraryName = @"vncserver";
+
+        /// <summary>
+        /// The name of the libvnclogger library. This is the compatibility layer.
+        /// </summary>
+        public const string LoggerLibraryName = @"vnclogger";
+
+        /// <summary>
+        /// The calling convention used by the libvncserver and libvnclogger libraries.
+        /// </summary>
+        public const CallingConvention LibraryCallingConvention = CallingConvention.Cdecl;
+
+        /// <summary>
+        /// The address of the <c>rfblog</c> field in the <c>vncserver</c> library.
+        /// </summary>
+        public static readonly IntPtr RfbLog;
+
+        /// <summary>
+        /// The address of the <c>rfbErr</c> field in the <c>vncserver</c> library.
+        /// </summary>
+        public static readonly IntPtr RfbErr;
+
+        /// <summary>
+        /// The address of the <c>vnclogger</c> library.
+        /// </summary>
+        public static readonly IntPtr LoggerLibrary;
+
+        /// <summary>
+        /// The address of the <c>LogMessage</c> function in the <c>vnclogger</c> library.
+        /// </summary>
+        public static readonly IntPtr LogMessage;
+
+        /// <summary>
+        /// The address of the <c>LogError</c> function in the <c>vnclogger</c> library.
+        /// </summary>
+        public static readonly IntPtr LogError;
+
+        /// <summary>
+        /// The address of the <c>logCallback</c> field in the <c>vnclogger</c> library.
+        /// </summary>
+        public static readonly IntPtr LogCallback;
+
+        /// <summary>
+        /// An instance of the delegate which will be used by the <c>vnclogger</c> library.
+        /// </summary>
+        public static readonly LogCallbackDelegateDefinition LogCallbackDelegate;
+
+        /// <summary>
+        /// A pointer to <see cref="RfbLogCallback(int, IntPtr, int)"/>.
+        /// </summary>
+        public static readonly IntPtr LogCallbackPtr;
+
+        public static ILogger Logger;
+
+        /// <summary>
+        /// Initializes static members of the <see cref="NativeLogging"/> class.
+        /// </summary>
+        static NativeLogging()
+        {
+            LoggerLibrary = NativeLibrary.Load(LoggerLibraryName, typeof(NativeLogging).Assembly, null);
+            LogMessage = NativeLibrary.GetExport(LoggerLibrary, "LogMessage");
+            LogMessage = NativeLibrary.GetExport(LoggerLibrary, "LogError");
+            LogCallback = NativeLibrary.GetExport(LoggerLibrary, "logCallback");
+
+            var vncServer = NativeLibrary.Load(ServerLibraryName, typeof(LibVncServer).Assembly, null);
+            RfbLog = NativeLibrary.GetExport(vncServer, "rfbLog");
+            RfbErr = NativeLibrary.GetExport(vncServer, "rfbErr");
+
+            Marshal.WriteIntPtr(RfbLog, NativeLogging.LogMessage);
+            Marshal.WriteIntPtr(RfbErr, NativeLogging.LogError);
+
+            LogCallbackDelegate = new LogCallbackDelegateDefinition(RfbLogCallback);
+            LogCallbackPtr = Marshal.GetFunctionPointerForDelegate(LogCallbackDelegate);
+            Marshal.WriteIntPtr(NativeLogging.LogCallback, LogCallbackPtr);
+        }
+
+        /// <summary>
+        /// The delegate used by the <c>logCallback</c> field in this <c>vnclogger</c> library.
+        /// </summary>
+        /// <param name="level">
+        /// The level of the log message (0 for messages and 1 for errors).
+        /// </param>
+        /// <param name="message">
+        /// A pointer to a <c>char*</c> which holds the message to log.
+        /// </param>
+        /// <param name="length">
+        /// The length of the message to log.
+        /// </param>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void LogCallbackDelegateDefinition(int level, IntPtr message, int length);
+
+        private static void RfbLogCallback(int level, IntPtr message, int length)
+        {
+            if (Logger == null)
+            {
+                return;
+            }
+
+            // Skip the terminating NULL character, and the terminating newline character
+            var text = Marshal.PtrToStringAnsi(message, length - 2);
+
+            if (level == 0)
+            {
+                Logger.LogError(text);
+            }
+            else
+            {
+                Logger.LogInformation(text);
+            }
+        }
+    }
+}
+#endif

--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -356,7 +356,7 @@ namespace RemoteViewing.LibVnc.Interop
         /// The server for which to determine whether it is still active.
         /// </param>
         /// <summary>
-        /// <see langword="true"/> if the server is still active; otherwise, <see langword="false"/>
+        /// <see langword="true"/> if the server is still active; otherwise, <see langword="false"/>.
         /// </summary>
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention, EntryPoint = "rfbIsActive")]
         public static extern byte rfbIsActive(RfbScreenInfoPtr screenInfo);

--- a/RemoteViewing.LibVnc/LibVncServer.cs
+++ b/RemoteViewing.LibVnc/LibVncServer.cs
@@ -95,6 +95,10 @@ namespace RemoteViewing.LibVnc
             this.rfbKbdAddEventHookPtr = Marshal.GetFunctionPointerForDelegate(this.rfbKbdAddEventHook);
             this.rfbPtrAddEventProcPtr = Marshal.GetFunctionPointerForDelegate(this.rfbPtrAddEventProc);
             this.rfbPasswordCheckProcPtr = Marshal.GetFunctionPointerForDelegate(this.rfbPasswordCheckProc);
+
+#if !NETSTANDARD2_0
+            NativeLogging.Logger = logger;
+#endif
         }
 
         /// <inheritdoc/>
@@ -187,13 +191,13 @@ namespace RemoteViewing.LibVnc
                 s.Start();
                 this.UpdateFramebuffer(this.server);
                 s.Stop();
-                this.logger.LogInformation($"Updated framebuffer. Took {s.ElapsedMilliseconds} ms.");
+                this.logger.LogDebug($"Updated framebuffer. Took {s.ElapsedMilliseconds} ms.");
 
                 s.Reset();
                 s.Start();
                 NativeMethods.rfbProcessEvents(this.server, usec);
                 s.Stop();
-                this.logger.LogInformation($"Processed server events. Took {s.ElapsedMilliseconds} ms.");
+                this.logger.LogDebug($"Processed server events. Took {s.ElapsedMilliseconds} ms.");
             }
 
             this.currentFramebufferHandle.Dispose();

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc is a .NET  VNC server library, which wraps around libvncserver.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.ServerExample/Program.cs
+++ b/RemoteViewing.ServerExample/Program.cs
@@ -80,7 +80,7 @@ namespace RemoteViewing.ServerExample
         private static IVncServer GetServer(bool useManaged)
         {
             var framebufferSource = new DummyFramebufferSource();
-            var logger = new ConsoleLogger("VNC", (s, l) => l <= LogLevel.Debug, true);
+            var logger = new ConsoleLogger("VNC", (s, l) => l > LogLevel.Debug, true);
 
             if (useManaged)
             {

--- a/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
+++ b/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
-    <PackageReference Include="Quamotion.RemoteViewing.LibVnc.NativeBinaries" Version="1.1.105" PrivateAssets="All" />
+    <PackageReference Include="Quamotion.RemoteViewing.LibVnc.NativeBinaries" Version="1.1.117" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Enable basic redirection of the logging output from `libvnserver` to an `ILogger` using the `vnclogger` interop library.

The current architecture of `libvncserver` means that log redirection is an all-or-nothing scenario; either _all_ output is redirected to a _single_ logger.
