### PR TITLE
Use the BGR pixel format

### DIFF
--- a/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbScreenInfoPtr.cs
@@ -156,11 +156,12 @@ namespace RemoteViewing.LibVnc.Interop
         }
 
         /// <summary>
-        /// Gets the pixel format.
+        /// Gets or sets the pixel format.
         /// </summary>
         public RfbPixelFormat ServerFormat
         {
             get { return Marshal.PtrToStructure<RfbPixelFormat>(this.handle + FieldOffsets[(int)RfbScreenInfoPtrField.ServerFormat]); }
+            set { Marshal.StructureToPtr<RfbPixelFormat>(value, this.handle + FieldOffsets[(int)RfbScreenInfoPtrField.ServerFormat], false); }
         }
 
         /// <summary>

--- a/RemoteViewing.LibVnc/LibVncServer.cs
+++ b/RemoteViewing.LibVnc/LibVncServer.cs
@@ -125,6 +125,13 @@ namespace RemoteViewing.LibVnc
 
             this.server = NativeMethods.rfbGetScreen(fb.Width, fb.Height, fb.PixelFormat.BlueBits, 3, fb.PixelFormat.BytesPerPixel);
 
+            var serverFormat = this.server.ServerFormat;
+            serverFormat.RedShift = 16;
+            serverFormat.GreenShift = 8;
+            serverFormat.BlueShift = 0;
+
+            this.server.ServerFormat = serverFormat;
+
             this.server.ListenInterface = MemoryMarshal.Read<int>(endPoint.Address.GetAddressBytes());
             this.server.AutoPort = false;
             this.server.Port = endPoint.Port;
@@ -218,6 +225,11 @@ namespace RemoteViewing.LibVnc
 
                 this.currentFramebuffer = this.memoryPool.Rent(fb.Width * fb.Height * 4);
                 this.currentFramebufferHandle = this.currentFramebuffer.Memory.Pin();
+
+                if (fb.PixelFormat != VncPixelFormat.RGB32)
+                {
+                    this.logger.LogWarning($"The pixel format {fb.PixelFormat} is not supported");
+                }
 
                 fb.GetBuffer().CopyTo(this.currentFramebuffer.Memory);
 

--- a/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
+++ b/RemoteViewing.NoVncExample/DummyFramebufferSource.cs
@@ -18,6 +18,10 @@ namespace RemoteViewing.NoVncExample
 
         private VncFramebuffer framebuffer;
 
+        // Override the color of the framebuffer. When set to transparent, an animation will be displayed
+        // instead.
+        private Color color = Color.Transparent;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DummyFramebufferSource"/> class.
         /// </summary>
@@ -78,7 +82,7 @@ namespace RemoteViewing.NoVncExample
 
             this.colors[colorIndex] = (byte)(this.colors[colorIndex] + this.increments[colorIndex]);
 
-            var color = Color.FromArgb(this.colors[0], this.colors[1], this.colors[2]);
+            var color = this.color == Color.Transparent ? Color.FromArgb(this.colors[0], this.colors[1], this.colors[2]) : this.color;
 
             using (Bitmap image = new Bitmap(this.Width, this.Height))
             using (Graphics gfx = Graphics.FromImage(image))
@@ -128,23 +132,54 @@ namespace RemoteViewing.NoVncExample
         /// <inheritdoc/>
         public void HandleKeyEvent(object sender, KeyChangedEventArgs e)
         {
-            if (e.Keysym == KeySym.Plus && e.Pressed == false)
+            // The following keys influence the framebuffer:
+            // + doubles the size of the framebuffer
+            // - custs the size of the framebuffer in half
+            // r rotates the framebuffer 90 degrees
+            // R sets the framebuffer to a _red_ screen
+            // G sets the framebuffer to a _green_ screen
+            // B sets the framebuffer to a _blue_ screen
+            // A sets the framebuffer to an _animating_ screen
+            //
+            // The R, G, B functions can be useful to make sure the individual color channels come through correctly (e.g. not swapping R/B channels)
+            // The A function can be useful to set the framerate
+            if (e.Keysym == KeySym.Plus && !e.Pressed)
             {
                 this.Width *= 2;
                 this.Height *= 2;
             }
 
-            if (e.Keysym == KeySym.Minus && e.Pressed == false)
+            if (e.Keysym == KeySym.Minus && !e.Pressed)
             {
                 this.Width /= 2;
                 this.Height /= 2;
             }
 
-            if (e.Keysym == KeySym.r && e.Pressed == false)
+            if (e.Keysym == KeySym.r && !e.Pressed)
             {
                 var temp = this.Width;
                 this.Width = this.Height;
                 this.Height = temp;
+            }
+
+            if (e.Keysym == KeySym.R && !e.Pressed)
+            {
+                this.color = Color.Red;
+            }
+
+            if (e.Keysym == KeySym.B && !e.Pressed)
+            {
+                this.color = Color.Blue;
+            }
+
+            if (e.Keysym == KeySym.G && !e.Pressed)
+            {
+                this.color = Color.Green;
+            }
+
+            if (e.Keysym == KeySym.A && !e.Pressed)
+            {
+                this.color = Color.Transparent;
             }
         }
     }


### PR DESCRIPTION
This aligns with the pixel format used by the managed implementation.

Extend the DummyFramebufferSource to support displaying an entirely red, green or blue framebuffer - allowing you to double-check color rendering.