### PR TITLE
Only call ClientFramebufferUpdateRequestHook when supported

### DIFF
--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -52,7 +52,7 @@ namespace RemoteViewing.LibVnc.Interop
 
             // rfbDefaultSetDesktopSize was introduced in version https://github.com/LibVNC/libvncserver/commit/8e41510f4a9d449dd228e5b3e29732882f7f5df6,
             // after 0.9.12 was cut.
-            IsVersion_0_9_13_OrNewer = NativeLibrary.GetExport(vncServer, "rfbDefaultSetDesktopSize") != IntPtr.Zero;
+            IsVersion_0_9_13_OrNewer = NativeLibrary.TryGetExport(vncServer, "rfbSendExtDesktopSize", out IntPtr _);
         }
 #endif
 

--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -42,6 +42,30 @@ namespace RemoteViewing.LibVnc.Interop
         /// </summary>
         public const string LibraryName = @"vncserver";
 
+#if !NETSTANDARD2_0
+        /// <summary>
+        /// Initializes static members of the <see cref="NativeMethods"/> class.
+        /// </summary>
+        static NativeMethods()
+        {
+            var vncServer = NativeLibrary.Load(LibraryName, typeof(NativeMethods).Assembly, null);
+
+            // rfbDefaultSetDesktopSize was introduced in version https://github.com/LibVNC/libvncserver/commit/8e41510f4a9d449dd228e5b3e29732882f7f5df6,
+            // after 0.9.12 was cut.
+            IsVersion_0_9_13_OrNewer = NativeLibrary.GetExport(vncServer, "rfbDefaultSetDesktopSize") != IntPtr.Zero;
+        }
+#endif
+
+        /// <summary>
+        /// Gets a value indicating whether the server is running version 0.9.13 or newer of libvncserver.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the server is running version 0.9.13 or newer of libvncserver;
+        /// otherwise, <see langword="false"/>.
+        /// </value>
+        public static bool IsVersion_0_9_13_OrNewer
+        { get; private set; }
+
         /// <summary>
         /// The calling convention used by the libvncserver library.
         /// </summary>

--- a/RemoteViewing.LibVnc/Interop/RfbClientRecPtr.cs
+++ b/RemoteViewing.LibVnc/Interop/RfbClientRecPtr.cs
@@ -252,8 +252,25 @@ namespace RemoteViewing.LibVnc.Interop
         /// </summary>
         public IntPtr ClientFramebufferUpdateRequestHook
         {
-            get { return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbClientRecPtrField.ClientFramebufferUpdateRequestHook]); }
-            set { Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbClientRecPtrField.ClientFramebufferUpdateRequestHook], value); }
+            get
+            {
+                if (!NativeMethods.IsVersion_0_9_13_OrNewer)
+                {
+                    throw new InvalidOperationException("ClientFramebufferUpdateRequestHook is available on libvncserver 0.9.13 or newer only.");
+                }
+
+                return Marshal.ReadIntPtr(this.handle, FieldOffsets[(int)RfbClientRecPtrField.ClientFramebufferUpdateRequestHook]);
+            }
+
+            set
+            {
+                if (!NativeMethods.IsVersion_0_9_13_OrNewer)
+                {
+                    throw new InvalidOperationException("ClientFramebufferUpdateRequestHook is available on libvncserver 0.9.13 or newer only.");
+                }
+
+                Marshal.WriteIntPtr(this.handle, FieldOffsets[(int)RfbClientRecPtrField.ClientFramebufferUpdateRequestHook], value);
+            }
         }
 
         /// <inheritdoc/>

--- a/RemoteViewing.LibVnc/LibVncServer.cs
+++ b/RemoteViewing.LibVnc/LibVncServer.cs
@@ -255,7 +255,11 @@ namespace RemoteViewing.LibVnc
             var minor = client.ProtocolMinorVersion;
 
             client.ClientGoneHook = this.clientGoneHookPtr;
-            client.ClientFramebufferUpdateRequestHook = this.clientFramebufferUpdateRequestHookPtr;
+
+            if (NativeMethods.IsVersion_0_9_13_OrNewer)
+            {
+                client.ClientFramebufferUpdateRequestHook = this.clientFramebufferUpdateRequestHookPtr;
+            }
 
             this.Connected?.Invoke(this, EventArgs.Empty);
 


### PR DESCRIPTION
ClientFramebufferUpdateRequestHook was added in https://github.com/LibVNC/libvncserver/commit/5eac9fa4b59d4628b49273dec142ec3e77cd65cb, which is not part of any released version of libvncserver, though it will likely ship in 0.9.13.

Detect 0.9.13 by checking for rfbDefaultSetDesktopSize which was added in https://github.com/LibVNC/libvncserver/commit/8e41510f4a9d449dd228e5b3e29732882f7f5df6, which is also a 0.9.13-only change.