### PR TITLE
LibVNC wrapper: Fix logging on Linux

### DIFF
--- a/RemoteViewing.LibVnc/Interop/NativeLogging.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLogging.cs
@@ -148,8 +148,8 @@ namespace RemoteViewing.LibVnc.Interop
                 return;
             }
 
-            // Skip the terminating NULL character, and the terminating newline character
-            var text = Marshal.PtrToStringAnsi(message, length - 2);
+            // Skip the terminating terminating newline character
+            var text = Marshal.PtrToStringAnsi(message, length - 1);
 
             if (level == 1)
             {


### PR DESCRIPTION
Use vasprintf on Linux, and vsprintf when compiling with msvc