### PR TITLE
Minor stability fixes

### DIFF
--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -54,7 +54,9 @@ namespace RemoteViewing.LibVnc.Interop
 
             // rfbDefaultSetDesktopSize was introduced in version https://github.com/LibVNC/libvncserver/commit/8e41510f4a9d449dd228e5b3e29732882f7f5df6,
             // after 0.9.12 was cut.
-            IsVersion_0_9_13_OrNewer = NativeLibrary.TryGetExport(nativeLibrary, "rfbSendExtDesktopSize", out IntPtr _);
+            IsVersion_0_9_13_OrNewer = 
+                nativeLibrary != IntPtr.Zero
+                && NativeLibrary.TryGetExport(nativeLibrary, "rfbSendExtDesktopSize", out IntPtr _);
         }
 
         public static IntPtr ResolveDll(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)

--- a/RemoteViewing.ServerExample/Program.cs
+++ b/RemoteViewing.ServerExample/Program.cs
@@ -59,7 +59,7 @@ namespace RemoteViewing.ServerExample
 
         public static void Main(string[] args)
         {
-            Console.WriteLine($"64-bit: {Environment.Is64BitProcess}");
+            Console.WriteLine($"64-bit: {Environment.Is64BitProcess}. PID {System.Diagnostics.Process.GetCurrentProcess().Id}");
 
             Console.WriteLine("Listening on local port 5900.");
             Console.WriteLine("Try to connect! The password is: {0}", password);

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,8 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- Avoid a NullReferenceException when the native library could not be loaded
- Fix building on non-Windows platforms
- Print out the process ID when starting the demo applications