### PR TITLE
Support for SIMATIC HMI TP1500 Comfort

### DIFF
--- a/RemoteViewing/Vnc/VncClient.Framebuffer.cs
+++ b/RemoteViewing/Vnc/VncClient.Framebuffer.cs
@@ -65,8 +65,10 @@ namespace RemoteViewing.Vnc
             {
                 var r = this.c.ReceiveRectangle();
                 int x = r.X, y = r.Y, w = r.Width, h = r.Height;
-                VncStream.SanityCheck(w > 0 && w < 0x8000);
-                VncStream.SanityCheck(h > 0 && h < 0x8000);
+
+                // we could receive 0,0 on an update rectangle with a "pseudo-encoding"
+                VncStream.SanityCheck(w >= 0 && w < 0x8000);
+                VncStream.SanityCheck(h >= 0 && h < 0x8000);
 
                 int fbW = this.Framebuffer.Width, fbH = this.Framebuffer.Height, bpp = this.Framebuffer.PixelFormat.BytesPerPixel;
                 var inRange = w <= fbW && h <= fbH && x <= fbW - w && y <= fbH - h;
@@ -262,6 +264,10 @@ namespace RemoteViewing.Vnc
                     case VncEncoding.PseudoDesktopSize:
                         this.Framebuffer = new VncFramebuffer(this.Framebuffer.Name, w, h, this.Framebuffer.PixelFormat);
                         continue; // Don't call OnFramebufferChanged for this one.
+
+                    case VncEncoding.PseudoCursor:
+                        // client requesting the Cursor pseudo-encoding
+                        continue;
 
                     default:
                         VncStream.Require(

--- a/RemoteViewing/Vnc/VncPixelFormat.cs
+++ b/RemoteViewing/Vnc/VncPixelFormat.cs
@@ -74,7 +74,7 @@ namespace RemoteViewing.Vnc
                 throw new ArgumentOutOfRangeException(nameof(bitsPerPixel));
             }
 
-            if (bitDepth != 6 && bitDepth != 24)
+            if (bitDepth != 6 && bitDepth != 24 && bitDepth != 32)
             {
                 throw new ArgumentOutOfRangeException(nameof(bitDepth));
             }
@@ -473,6 +473,12 @@ namespace RemoteViewing.Vnc
             var redShift = buffer[offset + 10];
             var greenShift = buffer[offset + 11];
             var blueShift = buffer[offset + 12];
+
+            // treat 32 bit depth as 24 bits
+            if (depth == 32)
+            {
+                depth = 24;
+            }
 
             return new VncPixelFormat(
                 bitsPerPixel,


### PR DESCRIPTION
This change adds support for the SIEMENS SIMATIC HMI TP1500 Comfort industrial touch screen's VNC client. 
This panel needed changes for the following unsupported behavior:

- Reports a bit depth of 32 bits - this change accepts and treats all 32 bit requests as 24 bits, 
- Requests the Cursor pseudo-encoding when a user clicks the touch panel's screen - this change does not disconnect on such message received

