### PR TITLE
Check out libvnc 0.9.13 on macOS, build without gcrypt

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -13,19 +13,16 @@ jobs:
     vmImage: 'macOS-10.14'
   steps:
   - script: |
-      wget -nv -nc https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$(LIBVNC_VERSION).tar.gz -O LibVNCServer-$(LIBVNC_VERSION).tar.gz
-      tar xzf LibVNCServer-$(LIBVNC_VERSION).tar.gz
-    condition: false
-    displayName: Download LibVNCServer
-  - script: |
       git clone --depth 1 --branch LibVNCServer-$(LIBVNC_VERSION) https://github.com/LibVNC/libvncserver/
+      git show
     displayName: Clone LibVNCServer
   - script: |
       mkdir build
       cd build
-      cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)/$(rid) ../libvncserver/
+      cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory)/$(rid) -DWITH_OPENSSL=OFF -DWITH_GCRYPT=OFF ../libvncserver/
     displayName: Configure LibVNC
   - script: |
+      cmake --build .
       make install
     workingDirectory: build
     displayName: Compile LibVNC
@@ -64,6 +61,7 @@ jobs:
   steps:
   - script: |
       git clone --branch LibVNCServer-$(LIBVNC_VERSION) --depth 1 https://github.com/LibVNC/libvncserver/
+      git show
     displayName: Clone LibVNCServer
   - task: Cache@2
     inputs:
@@ -111,7 +109,7 @@ jobs:
 
 - job: native_unix
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-20.04
   variables:
     rid: linux-x64
   container:
@@ -148,6 +146,7 @@ jobs:
   dependsOn:
   - native_windows
   - native_macos
+  - native_unix
   steps:
   - task: DownloadBuildArtifacts@0
     inputs:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     condition: false
     displayName: Download LibVNCServer
   - script: |
-      git clone --depth 1 https://github.com/LibVNC/libvncserver/
+      git clone --depth 1 --branch LibVNCServer-$(LIBVNC_VERSION) https://github.com/LibVNC/libvncserver/
     displayName: Clone LibVNCServer
   - script: |
       mkdir build

--- a/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
+++ b/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/RemoteViewing.Example/RemoteViewing.Example.csproj
+++ b/RemoteViewing.Example/RemoteViewing.Example.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
+++ b/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
@@ -49,7 +49,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
+++ b/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
+++ b/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />
     <PackageReference Include="Quamotion.RemoteViewing.LibVnc.NativeBinaries" Version="1.1.117" PrivateAssets="All" />
   </ItemGroup>

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="sharpcompress" Version="0.24.0" />
     <PackageReference Include="Quamotion.TurboJpegWrapper" Version="1.5.78" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.71" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />


### PR DESCRIPTION
- Build version 0.9.13
- Disable grcypt, openssl
- Bump Nerdbank.Gitversioning to fix build