### PR TITLE
Migrate to .NET 5.0

### DIFF
--- a/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
+++ b/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>RemoteViewing - ASP.NET Core noVNC Server.</AssemblyTitle>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.AspNetCore</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing.AspNetCore</PackageId>

--- a/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
+++ b/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc.NativeBinaries contains the native libvnc binaries, compiled for Windows and macOS.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
+++ b/RemoteViewing.LibVnc.Tests/RemoteViewing.LibVnc.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc is a .NET  VNC server library, which wraps around libvncserver.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
+++ b/RemoteViewing.NoVncExample/RemoteViewing.NoVncExample.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\RemoteViewing.AspNetCore\RemoteViewing.AspNetCore.csproj" />

--- a/RemoteViewing.NoVncExample/Startup.cs
+++ b/RemoteViewing.NoVncExample/Startup.cs
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using RemoteViewing.AspNetCore;
 
@@ -43,7 +44,7 @@ namespace RemoteViewing.NoVncExample
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             if (env.IsDevelopment())
             {

--- a/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
+++ b/RemoteViewing.ServerExample/RemoteViewing.ServerExample.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.ServerExample</AssemblyName>
     <OutputType>Exe</OutputType>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/RemoteViewing.Tests/RemoteViewing.Tests.csproj
+++ b/RemoteViewing.Tests/RemoteViewing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../RemoteViewing/RemoteViewing.snk</AssemblyOriginatorKeyFile>

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net45;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.Windows.Forms</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- Drop support for `netstandard2.1`, replace with `netstandard2.0` + `net5.0`
- Add support for `net5.0`