### PR TITLE
Migrate to .NET 4.6.2 as a the minimum .NET version

### DIFF
--- a/RemoteViewing.Example/RemoteViewing.Example.csproj
+++ b/RemoteViewing.Example/RemoteViewing.Example.csproj
@@ -12,10 +12,6 @@
     <CodeAnalysisRuleSet>..\RemoteViewing.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj" />
     <ProjectReference Include="..\RemoteViewing.Windows.Forms\RemoteViewing.Windows.Forms.csproj" />

--- a/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
+++ b/RemoteViewing.LibVnc.NativeBinaries/RemoteViewing.LibVnc.NativeBinaries.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc.NativeBinaries contains the native libvnc binaries, compiled for Windows and macOS.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.LibVnc/Interop/NativeLibraryLoader.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLibraryLoader.cs
@@ -9,12 +9,12 @@ namespace RemoteViewing.LibVnc.Interop
     {
         static NativeLibraryLoader()
         {
-#if !NETSTANDARD2_0 && !NET45
+#if !NETSTANDARD2_0 && !NET462
             NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, ResolveDll);
 #endif
         }
 
-#if !NETSTANDARD2_0 && !NET45
+#if !NETSTANDARD2_0 && !NET462
         public static IntPtr ResolveDll(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
         {
             IntPtr lib = IntPtr.Zero;

--- a/RemoteViewing.LibVnc/Interop/NativeLogging.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeLogging.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if !NETSTANDARD2_0 && !NET45
+#if !NETSTANDARD2_0 && !NET462
 using Microsoft.Extensions.Logging;
 using System;
 using System.Reflection;

--- a/RemoteViewing.LibVnc/Interop/NativeMethods.cs
+++ b/RemoteViewing.LibVnc/Interop/NativeMethods.cs
@@ -48,7 +48,7 @@ namespace RemoteViewing.LibVnc.Interop
         /// </summary>
         public const CallingConvention LibraryCallingConvention = CallingConvention.Cdecl;
 
-#if !NETSTANDARD2_0 && !NET45
+#if !NETSTANDARD2_0 && !NET462
         /// <summary>
         /// Initializes static members of the <see cref="NativeMethods"/> class.
         /// </summary>

--- a/RemoteViewing.LibVnc/LibVncServer.cs
+++ b/RemoteViewing.LibVnc/LibVncServer.cs
@@ -96,7 +96,7 @@ namespace RemoteViewing.LibVnc
             this.rfbPtrAddEventProcPtr = Marshal.GetFunctionPointerForDelegate(this.rfbPtrAddEventProc);
             this.rfbPasswordCheckProcPtr = Marshal.GetFunctionPointerForDelegate(this.rfbPasswordCheckProc);
 
-#if !NETSTANDARD2_0 && !NET45
+#if !NETSTANDARD2_0 && !NET462
             NativeLogging.Logger = logger;
 #endif
         }

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc is a .NET  VNC server library, which wraps around libvncserver.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.NoVncExample/bower.json
+++ b/RemoteViewing.NoVncExample/bower.json
@@ -2,6 +2,6 @@
   "name": "asp.net",
   "private": true,
   "dependencies": {
-    "no-vnc": "1.1.0"
+    "no-vnc": "1.3.0"
   }
 }

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.Windows.Forms</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -22,7 +22,7 @@
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/RemoteViewing.Windows.Forms/VncControl.Designer.cs
+++ b/RemoteViewing.Windows.Forms/VncControl.Designer.cs
@@ -1,6 +1,6 @@
 ﻿namespace RemoteViewing.Windows.Forms
 {
-#if NET45
+#if NET462
     partial class VncControl
     {
         /// <summary> 

--- a/RemoteViewing.Windows.Forms/VncControl.cs
+++ b/RemoteViewing.Windows.Forms/VncControl.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if NET45
+#if NET462
 using RemoteViewing.Vnc;
 using System;
 using System.Collections.Generic;

--- a/RemoteViewing.Windows.Forms/VncKeysym.cs
+++ b/RemoteViewing.Windows.Forms/VncKeysym.cs
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-#if NET45
+#if NET462
 using RemoteViewing.Vnc;
 using System;
 using System.Windows.Forms;

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -26,7 +26,6 @@
   <ItemGroup>
     <PackageReference Include="sharpcompress" Version="0.24.0" />
     <PackageReference Include="Quamotion.TurboJpegWrapper" Version="2.0.9" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Visual Studio 2022 no longer ships with a targeting pack for .NET 4.5