### PR TITLE
Bump noVNC to 1.2.0

### DIFF
--- a/RemoteViewing.AspNetCore/VncMiddleware.cs
+++ b/RemoteViewing.AspNetCore/VncMiddleware.cs
@@ -87,7 +87,8 @@ namespace RemoteViewing.AspNetCore
 
             if (context.WebSockets.IsWebSocketRequest)
             {
-                var socket = await context.WebSockets.AcceptWebSocketAsync("binary").ConfigureAwait(false);
+                var protocol = context.WebSockets.WebSocketRequestedProtocols.Count > 0 ? "binary" : null;
+                var socket = await context.WebSockets.AcceptWebSocketAsync(protocol).ConfigureAwait(false);
 
                 VncHandler<T> sockethandler = new VncHandler<T>(socket, vncContext);
                 await sockethandler.Listen().ConfigureAwait(false);

--- a/RemoteViewing.NoVncExample/bower.json
+++ b/RemoteViewing.NoVncExample/bower.json
@@ -2,6 +2,6 @@
   "name": "asp.net",
   "private": true,
   "dependencies": {
-    "no-vnc": "1.3.0"
+    "no-vnc": "1.2.0"
   }
 }


### PR DESCRIPTION
Newer version of noVNC no longer set the requested protocol header, so we should not specify any protocol when calling AcceptWebSocketAsync, either.