### PR TITLE
Bump TurboJpegWrapper to 2.0.21

### DIFF
--- a/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
+++ b/RemoteViewing.AspNetCore/RemoteViewing.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>RemoteViewing - ASP.NET Core noVNC Server.</AssemblyTitle>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.AspNetCore</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Quamotion.RemoteViewing.AspNetCore</PackageId>
@@ -24,8 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.0" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/RemoteViewing.AspNetCore/VncHandler.cs
+++ b/RemoteViewing.AspNetCore/VncHandler.cs
@@ -26,8 +26,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #endregion
 
-using Microsoft.AspNetCore.Http;
-using Nito.AsyncEx;
 using RemoteViewing.Vnc;
 using RemoteViewing.Vnc.Server;
 using System;
@@ -46,7 +44,7 @@ namespace RemoteViewing.AspNetCore
         /// This event will be reset when the conection with the client is lost, either because the client logged
         /// of or because of an error.
         /// </summary>
-        private readonly AsyncManualResetEvent closed = new AsyncManualResetEvent(false);
+        private readonly TaskCompletionSource<bool> closed = new TaskCompletionSource<bool>(false);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VncHandler{T}"/> class.
@@ -146,7 +144,7 @@ namespace RemoteViewing.AspNetCore
 
             this.Vnc.Connect(stream, options);
 
-            await this.closed.WaitAsync().ConfigureAwait(false);
+            await this.closed.Task.ConfigureAwait(false);
 
             this.Socket.Dispose();
         }
@@ -175,7 +173,7 @@ namespace RemoteViewing.AspNetCore
         /// </param>
         protected virtual void OnConnectionFailed(object sender, EventArgs e)
         {
-            this.closed.Set();
+            this.closed.SetResult(false);
         }
 
         /// <summary>
@@ -189,7 +187,7 @@ namespace RemoteViewing.AspNetCore
         /// </param>
         protected virtual void OnClosed(object sender, EventArgs e)
         {
-            this.closed.Set();
+            this.closed.SetResult(false);
         }
 
         /// <param name="sender">

--- a/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
+++ b/RemoteViewing.LibVnc/RemoteViewing.LibVnc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
     
     <Description>RemoteViewing.LibVnc is a .NET  VNC server library, which wraps around libvncserver.</Description>
     <AssemblyTitle>RemoteViewing.LibVnc - A .NET VNC server library.</AssemblyTitle>

--- a/RemoteViewing.Tests/RemoteViewing.Tests.csproj
+++ b/RemoteViewing.Tests/RemoteViewing.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
+	<PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Moq" Version="4.10.0" />

--- a/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
+++ b/RemoteViewing.Windows.Forms/RemoteViewing.Windows.Forms.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing.Windows.Forms</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -31,8 +31,8 @@
     <ProjectReference Include="..\RemoteViewing\RemoteViewing.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Drawing.Common" Version="4.6.1" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RemoteViewing/RemoteViewing.csproj
+++ b/RemoteViewing/RemoteViewing.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © 2013 James F. Bellinger &lt;http://www.zer7.com/software/remoteviewing&gt;</Copyright>
     <VersionPrefix>1.0.8</VersionPrefix>
     <Authors>James F. Bellinger, Frederik Carlier</Authors>
-    <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0</TargetFrameworks>
     <AssemblyName>RemoteViewing</AssemblyName>
     <AssemblyOriginatorKeyFile>RemoteViewing.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="sharpcompress" Version="0.24.0" />
-    <PackageReference Include="Quamotion.TurboJpegWrapper" Version="2.0.9" />
+    <PackageReference Include="Quamotion.TurboJpegWrapper" Version="2.0.21" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>

--- a/RemoteViewing/Vnc/Server/TightEncoder.cs
+++ b/RemoteViewing/Vnc/Server/TightEncoder.cs
@@ -197,7 +197,7 @@ namespace RemoteViewing.Vnc.Server
                     0, /* auto-calculate pitch */
                     region.Width,
                     region.Height,
-                    PixelFormat.Format32bppArgb,
+                    TJPixelFormat.BGRA,
                     subsamplingOption,
                     jpegQualityLevel,
                     TJFlags.NoRealloc);


### PR DESCRIPTION
- Drop netstandard2.0 support
- Remove dependency on Nito.AsyncEx